### PR TITLE
PHPUnit Testing Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ vendor/*
 
 # Node.js
 node_modules/
+
+# PHPUnit
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,8 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
-
-matrix:
-  include:
-    - php: 7.2
-      env: WP_VERSION=nightly WP_MULTISITE=0
-    - php: 7.2
-      env: WP_VERSION=nightly WP_MULTISITE=1
-    - php: 7.2
-      env: WP_VERSION=nightly WP_MULTISITE=0 WP_TRAVISCI=travis:codecoverage
+  - WP_VERSION=nightly WP_MULTISITE=0
+  - WP_VERSION=nightly WP_MULTISITE=1
 
 before_install:
   - |
@@ -47,21 +40,7 @@ before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-script:
-  - composer test
-  - |
-    if [[ "$WP_TRAVISCI" == "travis:codecoverage" ]] ; then
-      phpenv config-add /tmp/xdebug.ini || echo "xdebug.ini does not exist"
-      composer test -- --coverage-clover build/logs/clover.xml
-    else
-      composer test
-    fi
-
-after_script:
-  - |
-    if [[ "$WP_TRAVISCI" == "travis:codecoverage" ]] ; then
-      bash <(curl -s https://codecov.io/bash)
-    fi
+script: composer test
 
 jobs:
   fast_finish: true
@@ -69,8 +48,15 @@ jobs:
     - stage: lint
       script:
         - composer lint
+    - stage: coverage
+      before_install: skip
+      script:
+        - composer test -- --coverage-clover=coverage.xml
+      after_script:
+        - bash <(curl -s https://codecov.io/bash)
 
 stages:
   - lint
   - test
+  - coverage
   - deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 php:
   - 7.2
   - 7.1
-  - 7.0
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,12 @@ env:
 
 matrix:
   include:
-    - env: WP_VERSION=nightly
-    - env: WP_TRAVISCI=travis:codecoverage
+    - php: 7.2
+      env: WP_VERSION=nightly WP_MULTISITE=0
+    - php: 7.2
+      env: WP_VERSION=nightly WP_MULTISITE=1
+    - php: 7.2
+      env: WP_VERSION=nightly WP_MULTISITE=0 WP_TRAVISCI=travis:codecoverage
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+sudo: false
+dist: trusty
+
+language: php
+
+notifications:
+  email: false
+
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - composer install
+
+jobs:
+  fast_finish: true
+  include:
+    - stage: lint
+      script:
+        - composer lint
+
+    - stage: test
+      php: 7.2
+      env: WP_VERSION=latest
+      script:
+        - composer test
+        - WP_MULTISITE=1 composer test
+
+    - stage: test
+      php: 7.1
+      env: WP_VERSION=latest
+      script:
+        - composer test
+        - WP_MULTISITE=1 composer test
+
+    - stage: test
+      php: 7.0
+      env: WP_VERSION=latest
+      script:
+        - composer test
+        - WP_MULTISITE=1 composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,51 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+php:
+  - 7.2
+  - 7.1
+  - 7.0
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
+
+matrix:
+  include:
+    - env: WP_VERSION=nightly
+    - env: WP_TRAVISCI=travis:codecoverage
+
+before_install:
+  - |
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
+
 install:
   - composer install
+
+before_script:
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+
+script:
+  - composer test
+  - |
+    if [[ "$WP_TRAVISCI" == "travis:codecoverage" ]] ; then
+      phpenv config-add /tmp/xdebug.ini || echo "xdebug.ini does not exist"
+      composer test -- --coverage-clover build/logs/clover.xml
+    else
+      composer test
+    fi
+
+after_script:
+  - |
+    if [[ "$WP_TRAVISCI" == "travis:codecoverage" ]] ; then
+      bash <(curl -s https://codecov.io/bash)
+    fi
 
 jobs:
   fast_finish: true
@@ -24,23 +67,7 @@ jobs:
       script:
         - composer lint
 
-    - stage: test
-      php: 7.2
-      env: WP_VERSION=latest
-      script:
-        - composer test
-        - WP_MULTISITE=1 composer test
-
-    - stage: test
-      php: 7.1
-      env: WP_VERSION=latest
-      script:
-        - composer test
-        - WP_MULTISITE=1 composer test
-
-    - stage: test
-      php: 7.0
-      env: WP_VERSION=latest
-      script:
-        - composer test
-        - WP_MULTISITE=1 composer test
+stages:
+  - lint
+  - test
+  - deploy

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -150,7 +150,6 @@ install_db() {
 
 install_gp() {
 	# Set up GlotPress
-	echo "Loading GlotPress..."
 	git clone -q git://github.com/glotpress/glotpress-wp "$WP_CORE_DIR/build/wp-content/plugins/glotpress"
 }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_gp() {
+	# Set up GlotPress
+	echo "Loading GlotPress..."
+	git clone -q git://github.com/glotpress/glotpress-wp "$WP_CORE_DIR/src/wp-content/plugins/glotpress"
+}
+
+install_wp
+install_test_suite
+install_db
+install_gp

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -16,7 +16,7 @@ TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
-GP_TESTS_DIR="$WP_CORE_DIR/wp-content/plugins/glotpress/tests/phpunit"
+GP_TESTS_DIR="$WP_CORE_DIR/build/wp-content/plugins/glotpress/tests/phpunit"
 
 download() {
     if [ `which curl` ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -16,7 +16,7 @@ TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
-GP_TESTS_DIR="$WP_CORE_DIR/build/wp-content/plugins/glotpress/tests/phpunit"
+GP_TESTS_DIR="$WP_CORE_DIR/wp-content/plugins/glotpress/tests/phpunit"
 
 download() {
     if [ `which curl` ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -16,6 +16,7 @@ TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+GP_TESTS_DIR="$WP_CORE_DIR/build/wp-content/plugins/glotpress/tests/phpunit"
 
 download() {
     if [ `which curl` ]; then
@@ -150,7 +151,7 @@ install_db() {
 install_gp() {
 	# Set up GlotPress
 	echo "Loading GlotPress..."
-	git clone -q git://github.com/glotpress/glotpress-wp "$WP_CORE_DIR/src/wp-content/plugins/glotpress"
+	git clone -q git://github.com/glotpress/glotpress-wp "$WP_CORE_DIR/build/wp-content/plugins/glotpress"
 }
 
 install_wp

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,13 @@
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "dev-master",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+    "phpunit/phpunit": "^6"
   },
   "scripts": {
     "format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-    "lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source"
+    "lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source",
+    "test": "phpunit"
   },
   "suggest": {
     "wpackagist-plugin/slack": "Send Slack notifications upon ZIP file generation"
@@ -44,6 +46,11 @@
   "autoload": {
     "psr-4": {
       "Required\\Traduttore\\": "inc"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Required\\Traduttore\\Tests\\": "tests/phpunit/tests"
     }
   }
 }

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -65,10 +65,10 @@ class ProjectLocator {
 
 		$table = GP::$project->table;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		$query = $wpdb->prepare( "SELECT * FROM $table WHERE source_url_template LIKE %s LIMIT 1", '%' . $wpdb->esc_like( $this->project ) . '%' );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		return GP::$project->coerce( $wpdb->get_row( $query ) );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,8 @@
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs">
 		<exclude-pattern>*/tests/*</exclude-pattern>
+		<!-- Prevent false positives for IDE annotations -->
+		<exclude name="Squiz.PHP.CommentedOutCode"/>
 	</rule>
 
 	<!-- Check all PHP files in directory tree by default. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,9 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<rule ref="WordPress-Core" />
-	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-Docs">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
 
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>
@@ -26,10 +28,6 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!-- Exclude the unit tests from select sniffs. -->
-	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
 		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory suffix=".php">./tests/phpunit/tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,9 @@
 			<directory suffix=".php">./tests/phpunit/tests</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">inc</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -13,7 +13,7 @@ if ( ! $_tests_dir ) {
 }
 
 if ( ! $_gp_tests_dir ) {
-	$_gp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/wp-content/plugins/glotpress/tests/phpunit';
+	$_gp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/build/wp-content/plugins/glotpress/tests/phpunit';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Required\Traduttore
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ *
+ * Makes sure that GlotPress is fully installed and activer.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -6,9 +6,14 @@
  */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+$_gp_tests_dir = getenv( 'GP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! $_gp_tests_dir ) {
+	$_gp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/build/wp-content/plugins/glotpress/tests/phpunit';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
@@ -19,16 +24,13 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
-/**
- * Manually load the plugin being tested.
- *
- * Makes sure that GlotPress is fully installed and activer.
- */
-function _manually_load_plugin() {
-	require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
-}
+tests_add_filter( 'muplugins_loaded', function() use ( $_gp_tests_dir ) {
+	require_once $_gp_tests_dir . '/includes/loader.php';
 
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+	require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
+} );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+require_once $_gp_tests_dir . '/lib/testcase.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -21,6 +21,10 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
+if ( ! file_exists( $_gp_tests_dir . '/bootstrap.php' ) ) {
+	die( "GlotPress test suite could not be found. Have you run bin/install-wp-tests.sh ?\n" );
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
@@ -29,6 +33,11 @@ tests_add_filter( 'muplugins_loaded', function() use ( $_gp_tests_dir ) {
 
 	require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
 } );
+
+global $wp_tests_options;
+
+// So GlotPress doesn't bail early, see https://github.com/GlotPress/GlotPress-WP/blob/43bb5383e114835b09fc47c727d06e6d3ca8114e/glotpress.php#L142-L152.
+$wp_tests_options['permalink_structure'] = '/%postname%';
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -13,7 +13,7 @@ if ( ! $_tests_dir ) {
 }
 
 if ( ! $_gp_tests_dir ) {
-	$_gp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/build/wp-content/plugins/glotpress/tests/phpunit';
+	$_gp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/wp-content/plugins/glotpress/tests/phpunit';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,6 +25,8 @@ if ( ! file_exists( $_gp_tests_dir . '/bootstrap.php' ) ) {
 	die( "GlotPress test suite could not be found. Have you run bin/install-wp-tests.sh ?\n" );
 }
 
+putenv( "WP_TESTS_DIR=$_tests_dir" );
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,7 +5,7 @@
  * @package Required\Traduttore
  */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
+$_tests_dir    = getenv( 'WP_TESTS_DIR' );
 $_gp_tests_dir = getenv( 'GP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {
@@ -28,11 +28,13 @@ if ( ! file_exists( $_gp_tests_dir . '/bootstrap.php' ) ) {
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
-tests_add_filter( 'muplugins_loaded', function() use ( $_gp_tests_dir ) {
-	require_once $_gp_tests_dir . '/includes/loader.php';
+tests_add_filter(
+	'muplugins_loaded', function() use ( $_gp_tests_dir ) {
+		require_once $_gp_tests_dir . '/includes/loader.php';
 
-	require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
-} );
+		require dirname( dirname( __DIR__ ) ) . '/traduttore.php';
+	}
+);
 
 global $wp_tests_options;
 

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -8,7 +8,7 @@
 namespace Required\Traduttore\Tests;
 
 use \GP_UnitTestCase;
-use \Required\Traduttore\ProjectLocator as PL;
+use \Required\Traduttore\ProjectLocator as Locator;
 
 /**
  *  Test cases for \Required\Traduttore\ProjectLocator.
@@ -32,8 +32,55 @@ class ProjectLocator extends GP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->root   = $this->factory->project->create( array( 'name' => 'Root' ) );
-		$this->sub    = $this->factory->project->create( array( 'name' => 'Sub', 'parent_project_id' => $root->id ) );
-		$this->subsub = $this->factory->project->create( array( 'name' => 'SubSub', 'parent_project_id' => $sub->id ) );
+		$this->root   = $this->factory->project->create( [ 'name' => 'Root' ] );
+		$this->sub    = $this->factory->project->create(
+			[
+				'name'              => 'Sub',
+				'parent_project_id' => $this->root->id,
+			]
+		);
+		$this->subsub = $this->factory->project->create(
+			[
+				'name'                => 'SubSub',
+				'parent_project_id'   => $this->sub->id,
+				'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
+			]
+		);
+	}
+
+	public function test_find_project_by_glotpress_path() {
+		$locator = new Locator( 'root' );
+
+		$this->assertEquals( $locator->get_project()->id, $this->root->id );
+	}
+
+	public function test_find_project_by_glotpress_subpath() {
+		$locator = new Locator( 'root/sub' );
+
+		$this->assertEquals( $locator->get_project()->id, $this->sub->id );
+	}
+
+	public function test_find_project_by_glotpress_subsubpath() {
+		$locator = new Locator( 'root/sub/subsub' );
+
+		$this->assertEquals( $locator->get_project()->id, $this->subsub->id );
+	}
+
+	public function test_find_project_by_glotpress_id() {
+		$locator = new Locator( (int) $this->sub->id );
+
+		$this->assertEquals( $locator->get_project()->id, $this->sub->id );
+	}
+
+	public function test_find_project_by_glotpress_id_as_string() {
+		$locator = new Locator( (string) $this->sub->id );
+
+		$this->assertEquals( $locator->get_project()->id, $this->sub->id );
+	}
+
+	public function test_find_project_by_github_url() {
+		$locator = new Locator( 'https://github.com/wearerequired/traduttore' );
+
+		$this->assertEquals( $locator->get_project()->id, $this->subsub->id );
 	}
 }

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Class GetPushResources
+ *
+ * @package H2push
+ */
+
+namespace Required\Traduttore\Tests;
+
+use \WP_UnitTestCase;
+use \Required\Traduttore\ProjectLocator as PL;
+
+/**
+ *  Test cases for \Required\Traduttore\ProjectLocator.
+ */
+class ProjectLocator extends WP_UnitTestCase {
+
+}

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -7,12 +7,33 @@
 
 namespace Required\Traduttore\Tests;
 
-use \WP_UnitTestCase;
+use \GP_UnitTestCase;
 use \Required\Traduttore\ProjectLocator as PL;
 
 /**
  *  Test cases for \Required\Traduttore\ProjectLocator.
  */
-class ProjectLocator extends WP_UnitTestCase {
+class ProjectLocator extends GP_UnitTestCase {
+	/**
+	 * @var \GP_Project
+	 */
+	public $root;
 
+	/**
+	 * @var \GP_Project
+	 */
+	public $sub;
+
+	/**
+	 * @var \GP_Project
+	 */
+	public $subsub;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->root   = $this->factory->project->create( array( 'name' => 'Root' ) );
+		$this->sub    = $this->factory->project->create( array( 'name' => 'Sub', 'parent_project_id' => $root->id ) );
+		$this->subsub = $this->factory->project->create( array( 'name' => 'SubSub', 'parent_project_id' => $sub->id ) );
+	}
 }


### PR DESCRIPTION
* Installs PHPUnit ^6.0 as that's the only one WordPress is compatible with
* Adds a lightweight Travis CI configuration (#20)
* Downloads GlotPress in `bin/install-wp-tests.sh`

Todo:

* Figure out best way to install GlotPress so we can add some integration tests.  
  For https://github.com/swissspidy/glotpress-json I installed the whole GlotPress test suite. Not sure that's the best option.

Fixes #18.