### PR TITLE
Use `__invoke()` for CLI command classes with no sub-commands

### DIFF
--- a/inc/cli/BuildCommand.php
+++ b/inc/cli/BuildCommand.php
@@ -44,7 +44,7 @@ class BuildCommand extends WP_CLI_Command {
 	 * @param array $args Command args.
 	 * @param array $assoc_args Associative args.
 	 */
-	public function __construct( $args, $assoc_args ) {
+	public function __invoke( $args, $assoc_args ) {
 		if ( is_numeric( $args[0] ) ) {
 			$project = GP::$project->get( $args[0] );
 		} else {

--- a/inc/cli/UpdateCommand.php
+++ b/inc/cli/UpdateCommand.php
@@ -52,7 +52,7 @@ class UpdateCommand extends WP_CLI_Command {
 	 * @param array $args Command args.
 	 * @param array $assoc_args Associative args.
 	 */
-	public function __construct( $args, $assoc_args ) {
+	public function __invoke( $args, $assoc_args ) {
 		$locator = new ProjectLocator( $args[0] );
 		$project = $locator->get_project();
 


### PR DESCRIPTION
```
$ wp traduttore update https://github.com/wearerequired/yolo
Error: 'https://github.com/wearerequired/yolo' is not a registered subcommand of 'traduttore update'. See 'wp help traduttore update' for available subcommands.
```