### PR TITLE
Check if build time is set

### DIFF
--- a/inc/TranslationApiRoute.php
+++ b/inc/TranslationApiRoute.php
@@ -50,7 +50,7 @@ class TranslationApiRoute extends GP_Route_Main {
 
 			$zip_provider = new ZipProvider( $set );
 
-			if ( ! file_exists( $zip_provider->get_zip_path() ) ) {
+			if ( ! file_exists( $zip_provider->get_zip_path() || $zip_provider->get_last_build_time() === false ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
I came across the problem where the translations were not updating as the "updated" value was `false` which caused [WP-CLI ](https://github.com/wp-cli/language-command/blob/master/src/WP_CLI/LanguagePackUpgrader.php#L78) to save the translations zip without an updated time. This meant there was always an update for the plugin but it was not really updated.

This problem arose as the zip files were created before the new feature for the updated time was added. I think it is better to be cautious and not show the zip information if crucial data is missing.