### PR TITLE
Ensure we pass around Project instances everywhere

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,7 +12,7 @@ Fires after translations have been updated.
 
 **Parameters:**
 
-* `$project`: The GlotPress project that was updated.
+* `$project`: The project that was updated.
 * `$stats`: Stats about the number of imported translations.
 * `$translations`: PO object containing all the translations from the POT file.
 
@@ -81,7 +81,7 @@ Filters whether a Slack notification for translation updates from GitHub should 
 
 * `$send_message`: Whether to send a notification or not. Default true.
 * `$translation_set`: Translation set the ZIP is for.
-* `$project`: The GlotPress project that was updated.
+* `$project`: The project that was updated.
 
 ----
 
@@ -95,7 +95,7 @@ Filters the Slack notification message when a new translation ZIP file is built.
 
 * `$message`: The notification message.
 * `$translation_set`: Translation set the ZIP is for.
-* `$project`: The GlotPress project that was updated.
+* `$project`: The project that was updated.
 
 ----
 
@@ -110,7 +110,7 @@ Make sure to set up Slack notifications first, as outlined in the [Notifications
 **Parameters:**
 
 * `$send_message`: Whether to send a notification or not. Defaults to true, unless there were no string changes at all.
-* `$project`: The GlotPress project that was updated.
+* `$project`: The project that was updated.
 * `$stats`: Stats about the number of imported translations.
 
 ----
@@ -124,7 +124,7 @@ Filters the Slack notification message when new translations are updated.
 **Parameters:**
 
 * `$message`: The notification message.
-* `$project`: The GlotPress project that was updated.
+* `$project`: The project that was updated.
 * `$stats`: Stats about the number of imported translations.
 
 ----

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -136,7 +136,7 @@ class Plugin {
 						$message = sprintf(
 							'<%1$s|%2$s>: ZIP file updated for *%3$s*. (<%4$s|Download>)',
 							home_url( gp_url_project( $project ) ),
-							$project->get_project()->name,
+							$project->get_name(),
 							$locale->english_name,
 							$zip_url
 						);
@@ -187,7 +187,7 @@ class Plugin {
 						$message = sprintf(
 							'<%1$s|%2$s>: *%3$d* new strings were added, *%4$d* were fuzzied, and *%5$d* were obsoleted. There were *%6$d* errors.',
 							home_url( gp_url_project( $project ) ),
-							$project->get_project()->name,
+							$project->get_name(),
 							$originals_added,
 							$originals_fuzzied,
 							$originals_obsoleted,

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -116,7 +116,7 @@ class Plugin {
 					'message'     => function( $zip_path, $zip_url, GP_Translation_Set $translation_set ) {
 						/* @var GP_Locale $locale */
 						$locale  = GP_Locales::by_slug( $translation_set->locale );
-						$project = GP::$project->get( $translation_set->project_id );
+						$project = new Project( GP::$project->get( $translation_set->project_id ) );
 
 						/**
 						 * Filters whether a Slack notification for translation updates from GitHub should be sent.
@@ -125,7 +125,7 @@ class Plugin {
 						 *
 						 * @param bool               $send_message    Whether to send a notification or not. Default true.
 						 * @param GP_Translation_Set $translation_set Translation set the ZIP is for.
-						 * @param GP_Project         $project         The GlotPress project that was updated.
+						 * @param Project            $project         The project that was updated.
 						 */
 						$send_message = apply_filters( 'traduttore.zip_generated_send_notification', true, $translation_set, $project );
 
@@ -136,7 +136,7 @@ class Plugin {
 						$message = sprintf(
 							'<%1$s|%2$s>: ZIP file updated for *%3$s*. (<%4$s|Download>)',
 							home_url( gp_url_project( $project ) ),
-							$project->name,
+							$project->get_project()->name,
 							$locale->english_name,
 							$zip_url
 						);
@@ -157,7 +157,7 @@ class Plugin {
 				$events['traduttore.updated'] = [
 					'action'      => 'traduttore.updated',
 					'description' => __( 'When new translations are updated for a project', 'traduttore' ),
-					'message'     => function( GP_Project $project, array $stats ) {
+					'message'     => function( Project $project, array $stats ) {
 						[
 							$originals_added,
 							$originals_existing,
@@ -173,10 +173,10 @@ class Plugin {
 						 *
 						 * @since 3.0.0
 						 *
-						 * @param bool       $send_message Whether to send a notification or not.
-						 *                                 Defaults to true, unless there were no string changes at all.
-						 * @param GP_Project $project      The GlotPress project that was updated.
-						 * @param array      $stats        Stats about the number of imported translations.
+						 * @param bool    $send_message Whether to send a notification or not.
+						 *                              Defaults to true, unless there were no string changes at all.
+						 * @param Project $project      The Project that was updated.
+						 * @param array   $stats        Stats about the number of imported translations.
 						 */
 						$send_message = apply_filters( 'traduttore.updated_send_notification', $send_message, $project, $stats );
 
@@ -187,7 +187,7 @@ class Plugin {
 						$message = sprintf(
 							'<%1$s|%2$s>: *%3$d* new strings were added, *%4$d* were fuzzied, and *%5$d* were obsoleted. There were *%6$d* errors.',
 							home_url( gp_url_project( $project ) ),
-							$project->name,
+							$project->get_project()->name,
 							$originals_added,
 							$originals_fuzzied,
 							$originals_obsoleted,
@@ -199,9 +199,9 @@ class Plugin {
 						 *
 						 * @since 3.0.0
 						 *
-						 * @param string     $message The notification message.
-						 * @param GP_Project $project The GlotPress project that was updated.
-						 * @param array      $stats   Stats about the number of imported translations.
+						 * @param string  $message The notification message.
+						 * @param Project $project The project that was updated.
+						 * @param array   $stats   Stats about the number of imported translations.
 						 */
 						return apply_filters( 'traduttore.updated_notification_message', $message, $project, $stats );
 					},

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -123,6 +123,17 @@ class Project {
 	}
 
 	/**
+	 * Returns the project's name.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string Project name.
+	 */
+	public function get_name(): string {
+		return $this->project->name;
+	}
+
+	/**
 	 * Returns the project's slug.
 	 *
 	 * @since 3.0.0

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -135,7 +135,7 @@ class Updater {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param Project $project      The GlotPress project that was updated.
+		 * @param Project $project      The project that was updated.
 		 * @param array   $stats        Stats about the number of imported translations.
 		 * @param PO      $translations PO object containing all the translations from the POT file.
 		 */

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -44,6 +44,10 @@ class Project extends GP_UnitTestCase {
 		$this->assertSame( $this->gp_project->id, $this->project->get_id() );
 	}
 
+	public function test_get_name(): void {
+		$this->assertSame( 'Project', $this->project->get_name() );
+	}
+
 	public function test_get_slug(): void {
 		$this->assertSame( $this->gp_project->slug, $this->project->get_slug() );
 	}


### PR DESCRIPTION
**Description**

I got a PHP error when running `wp cron event run traduttore.update` with the current master version because the ?`traduttore.updated` action passes a `Project` instance now instead of `GP_Project`.

```
Fatal error: Uncaught TypeError: Argument 1 passed to Required\Traduttore\Plugin::Required\Traduttore\{closure}() must be an instance of GP_Project, instance of Required\Traduttore\Project given, called in /.../wordpress/content/plugins/slack/includes/event-manager.php on line 243 and defined in /...wordpress/content/plugins/traduttore/inc/Plugin.php:160
```

**How has this been tested?**
Fire a webhook so that a cron event is scheduled, then run `wp cron event run traduttore.update` and notice the error. Apply PR to fix error.

**Types of changes**
Bug fix for `traduttore.updated` action params.

Also updates docs to not refer to "GlotPress projects" but just "projects" to reduce confusion.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
