### PR TITLE
Delete GlotPress meta data on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -8,6 +8,7 @@
 namespace Required\Traduttore;
 
 use WP_Filesystem_Base;
+use wpdb;
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
@@ -17,16 +18,27 @@ global $wp_filesystem;
 if ( ! $wp_filesystem ) {
 	require_once ABSPATH . '/wp-admin/includes/admin.php';
 
-	if ( ! \WP_Filesystem() ) {
-		return false;
-	}
+	\WP_Filesystem();
 }
 
-array_map(
-	function ( $file_or_folder ) use ( $wp_filesystem ) {
-		$wp_filesystem->delete( $file_or_folder, true, is_dir( $file_or_folder ) ? 'd' : 'f' );
-	},
-	glob( get_temp_dir() . 'traduttore-*' )
-);
+if ( $wp_filesystem ) {
+	array_map(
+		function ( $file_or_folder ) use ( $wp_filesystem ) {
+			$wp_filesystem->delete( $file_or_folder, true, is_dir( $file_or_folder ) ? 'd' : 'f' );
+		},
+		glob( get_temp_dir() . 'traduttore-*' )
+	);
 
-$wp_filesystem->rmdir( ZipProvider::get_cache_dir(), true );
+	$wp_filesystem->rmdir( ZipProvider::get_cache_dir(), true );
+}
+
+/* @var wpdb $wpdb */
+global $wpdb;
+
+$meta_key_prefix = '_traduttore_';
+
+// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+$query = $wpdb->prepare( "DELETE FROM `$wpdb->gp_meta` WHERE `meta_key` LIKE %s ", $wpdb->esc_like( $meta_key_prefix ) . '%' );
+
+// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+$wpdb->query( $query );


### PR DESCRIPTION
**Description**

Fixes #71 by deleting meta data upon plugin uninstall.

**How has this been tested?**
Not yet 🙃 

**Types of changes**
Extends uninstall routine to delete project and translation set meta data from GlotPress meta table.

**Checklist:**
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
