### PR TITLE
Support per-project webhook secrets

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -152,3 +152,17 @@ Filters the delay for scheduled project updates.
 
 * `$delay`: Delay in minutes. Default is 3 minutes.
 * `$project`: The current project.
+
+----
+
+### `traduttore.webhook_secret`
+
+**Since:** 3.0.0
+
+Filters the sync secret for an incoming webhook request.
+
+**Parameters:**
+
+* `$secret`: Webhook sync secret.
+* `$handler`: The current webhook handler instance.
+* `$project`: The current project if found.

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -81,6 +81,15 @@ class Project {
 	protected const REPOSITORY_HTTPS_URL_KEY = '_traduttore_repository_https_url';
 
 	/**
+	 * Project repository webhook sync secret meta key.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string Project repository name meta key.
+	 */
+	protected const REPOSITORY_WEBHOOK_SECRET_KEY = '_traduttore_repository_webhook_secret';
+
+	/**
 	 * GlotPress project.
 	 *
 	 * @since 3.0.0
@@ -328,5 +337,30 @@ class Project {
 	 */
 	public function set_repository_https_url( string $url ): bool {
 		return (bool) gp_update_meta( $this->project->id, static::REPOSITORY_HTTPS_URL_KEY, $url, 'project' );
+	}
+
+	/**
+	 * Returns the project's repository webhook sync secret.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Webhook sync secret if stored, null otherwise.
+	 */
+	public function get_repository_webhook_secret(): ?string {
+		$name = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_WEBHOOK_SECRET_KEY );
+
+		return $name ?: null;
+	}
+
+	/**
+	 * Updates the project's repository webhook sync secret.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $name The new secret.
+	 * @return bool Whether the data was successfully saved or not.
+	 */
+	public function set_repository_webhook_secret( string $name ): bool {
+		return (bool) gp_update_meta( $this->project->id, static::REPOSITORY_WEBHOOK_SECRET_KEY, $name, 'project' );
 	}
 }

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -61,13 +61,11 @@ abstract class Base implements WebhookHandler {
 				if ( defined( 'TRADUTTORE_GITHUB_SYNC_SECRET' ) ) {
 					$secret = TRADUTTORE_GITHUB_SYNC_SECRET;
 				}
-
 				break;
 			case GitLab::class:
 				if ( defined( 'TRADUTTORE_GITLAB_SYNC_SECRET' ) ) {
 					$secret = TRADUTTORE_GITLAB_SYNC_SECRET;
 				}
-
 				break;
 		}
 

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -9,6 +9,7 @@
 
 namespace Required\Traduttore\WebhookHandler;
 
+use Required\Traduttore\Project;
 use Required\Traduttore\WebhookHandler;
 use WP_REST_Request;
 
@@ -36,5 +37,49 @@ abstract class Base implements WebhookHandler {
 	 */
 	public function __construct( WP_REST_Request $request ) {
 		$this->request = $request;
+	}
+
+	/**
+	 * Returns the webhook sync secret.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param Project|null $project The current project if found.
+	 *
+	 * @return string Secret if set, null otherwise.
+	 */
+	protected function get_secret( Project $project = null ): ?string {
+		$secret = $project ? $project->get_repository_webhook_secret() : null;
+
+		switch ( get_class( $this ) ) {
+			case Bitbucket::class:
+				if ( defined( 'TRADUTTORE_BITBUCKET_SYNC_SECRET' ) ) {
+					$secret = TRADUTTORE_BITBUCKET_SYNC_SECRET;
+				}
+				break;
+			case GitHub::class:
+				if ( defined( 'TRADUTTORE_GITHUB_SYNC_SECRET' ) ) {
+					$secret = TRADUTTORE_GITHUB_SYNC_SECRET;
+				}
+
+				break;
+			case GitLab::class:
+				if ( defined( 'TRADUTTORE_GITLAB_SYNC_SECRET' ) ) {
+					$secret = TRADUTTORE_GITLAB_SYNC_SECRET;
+				}
+
+				break;
+		}
+
+		/**
+		 * Filters the sync secret for an incoming webhook request.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string         $secret  Webhook sync secret.
+		 * @param WebhookHandler $handler The current webhook handler instance.
+		 * @param Project|null   $project The current project if found.
+		 */
+		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
 	}
 }

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -49,7 +49,7 @@ abstract class Base implements WebhookHandler {
 	 * @return string Secret if set, null otherwise.
 	 */
 	protected function get_secret( Project $project = null ): ?string {
-		$secret = $project ? $project->get_repository_webhook_secret() : null;
+		$secret = null;
 
 		switch ( get_class( $this ) ) {
 			case Bitbucket::class:
@@ -68,6 +68,10 @@ abstract class Base implements WebhookHandler {
 				}
 				break;
 		}
+
+		$project_secret = $project ? $project->get_repository_webhook_secret() : null;
+
+		$secret = $project_secret ?? $secret;
 
 		/**
 		 * Filters the sync secret for an incoming webhook request.

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -78,7 +78,7 @@ abstract class Base implements WebhookHandler {
 		 *
 		 * @param string         $secret  Webhook sync secret.
 		 * @param WebhookHandler $handler The current webhook handler instance.
-		 * @param Project|null   $project The current project if found.
+		 * @param Project|null   $project The current project if passed through.
 		 */
 		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
 	}

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -103,32 +103,4 @@ class Bitbucket extends Base {
 
 		return new WP_REST_Response( [ 'result' => 'OK' ] );
 	}
-
-	/**
-	 * Returns the webhook sync secret.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param Project|null $project The current project if found.
-	 *
-	 * @return string Secret if set, null otherwise.
-	 */
-	protected function get_secret( Project $project = null ): ?string {
-		$secret = $project ? $project->get_repository_webhook_secret() : null;
-
-		if ( defined( 'TRADUTTORE_BITBUCKET_SYNC_SECRET' ) ) {
-			$secret = TRADUTTORE_BITBUCKET_SYNC_SECRET;
-		}
-
-		/**
-		 * Filters the sync secret for an incoming webhook request.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string         $secret  Webhook sync secret.
-		 * @param WebhookHandler $handler The current webhook handler instance.
-		 * @param Project|null   $project The current project if found.
-		 */
-		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
-	}
 }

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -105,32 +105,4 @@ class GitHub extends Base {
 
 		return new WP_REST_Response( [ 'result' => 'OK' ] );
 	}
-
-	/**
-	 * Returns the webhook sync secret.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param Project|null $project The current project if found.
-	 *
-	 * @return string Secret if set, null otherwise.
-	 */
-	protected function get_secret( Project $project = null ): ?string {
-		$secret = $project ? $project->get_repository_webhook_secret() : null;
-
-		if ( defined( 'TRADUTTORE_GITHUB_SYNC_SECRET' ) ) {
-			$secret = TRADUTTORE_GITHUB_SYNC_SECRET;
-		}
-
-		/**
-		 * Filters the sync secret for an incoming webhook request.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string         $secret  Webhook sync secret.
-		 * @param WebhookHandler $handler The current webhook handler instance.
-		 * @param Project|null   $project The current project if found.
-		 */
-		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
-	}
 }

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -9,9 +9,11 @@
 
 namespace Required\Traduttore\WebhookHandler;
 
+use Required\Traduttore\Project;
 use Required\Traduttore\ProjectLocator;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Updater;
+use Required\Traduttore\WebhookHandler;
 use WP_Error;
 use WP_REST_Response;
 
@@ -41,17 +43,19 @@ class GitHub extends Base {
 			return false;
 		}
 
-		if ( ! defined( 'TRADUTTORE_GITHUB_SYNC_SECRET' ) ) {
-			return false;
-		}
-
 		$token = $this->request->get_header( 'x-hub-signature' );
 
 		if ( ! $token ) {
 			return false;
 		}
 
-		$payload_signature = 'sha1=' . hash_hmac( 'sha1', $this->request->get_body(), TRADUTTORE_GITHUB_SYNC_SECRET );
+		$params  = $this->request->get_params();
+		$locator = new ProjectLocator( $params['repository']['html_url'] ?? null );
+		$project = $locator->get_project();
+
+		$secret = $this->get_secret( $project );
+
+		$payload_signature = 'sha1=' . hash_hmac( 'sha1', $this->request->get_body(), $secret );
 
 		return hash_equals( $token, $payload_signature );
 	}
@@ -100,5 +104,33 @@ class GitHub extends Base {
 		( new Updater( $project ) )->schedule_update();
 
 		return new WP_REST_Response( [ 'result' => 'OK' ] );
+	}
+
+	/**
+	 * Returns the webhook sync secret.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param Project|null $project The current project if found.
+	 *
+	 * @return string Secret if set, null otherwise.
+	 */
+	protected function get_secret( Project $project = null ): ?string {
+		$secret = $project ? $project->get_repository_webhook_secret() : null;
+
+		if ( defined( 'TRADUTTORE_GITHUB_SYNC_SECRET' ) ) {
+			$secret = TRADUTTORE_GITHUB_SYNC_SECRET;
+		}
+
+		/**
+		 * Filters the sync secret for an incoming webhook request.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string         $secret  Webhook sync secret.
+		 * @param WebhookHandler $handler The current webhook handler instance.
+		 * @param Project|null   $project The current project if found.
+		 */
+		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
 	}
 }

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -98,32 +98,4 @@ class GitLab extends Base {
 
 		return new WP_REST_Response( [ 'result' => 'OK' ] );
 	}
-
-	/**
-	 * Returns the webhook sync secret.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param Project|null $project The current project if found.
-	 *
-	 * @return string Secret if set, null otherwise.
-	 */
-	protected function get_secret( Project $project = null ): ?string {
-		$secret = $project ? $project->get_repository_webhook_secret() : null;
-
-		if ( defined( 'TRADUTTORE_GITLAB_SYNC_SECRET' ) ) {
-			$secret = TRADUTTORE_GITLAB_SYNC_SECRET;
-		}
-
-		/**
-		 * Filters the sync secret for an incoming webhook request.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string         $secret  Webhook sync secret.
-		 * @param WebhookHandler $handler The current webhook handler instance.
-		 * @param Project|null   $project The current project if found.
-		 */
-		return apply_filters( 'traduttore.webhook_secret', $secret, $this, $project );
-	}
 }


### PR DESCRIPTION
**Description**
This adds new methods to the `Project` class to set and retrieve webhook secrets.

Since the secrets are needed in the permission callbacks the webhook handlers are updated accordingly to locate the projects earlier in the process.

Fixes #80.

**How has this been tested?**

Unit tests still work 🙂 

**Types of changes**
Enhanced `Project` class, added new protected methods to the webhook handlers with a new `traduttore.webhook_secret` filter.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
