### PR TITLE
Add --cached flag to update command

### DIFF
--- a/inc/CLI/UpdateCommand.php
+++ b/inc/CLI/UpdateCommand.php
@@ -31,7 +31,7 @@ class UpdateCommand extends WP_CLI_Command {
 	 * : Project path / ID or source code repository URL, e.g. https://github.com/wearerequired/required-valencia
 	 *
 	 * [--cached]
-	 * : Used cached repository information and do not try to download code from remote.
+	 * : Use cached repository information and do not try to download code from remote.
 	 *
 	 * [--delete]
 	 * : Whether to first delete the existing local repository or not.

--- a/inc/CLI/UpdateCommand.php
+++ b/inc/CLI/UpdateCommand.php
@@ -15,6 +15,7 @@ use WP_CLI_Command;
 use function WP_CLI\Utils\get_flag_value;
 
 /**
+ * Translation update command class.
  *
  * @since 2.0.0
  */

--- a/inc/CLI/UpdateCommand.php
+++ b/inc/CLI/UpdateCommand.php
@@ -15,14 +15,17 @@ use WP_CLI_Command;
 use function WP_CLI\Utils\get_flag_value;
 
 /**
- * Updates project translations from GitHub repository.
+ * Updates project translations from source code repository.
  *
  * Finds the project the repository belongs to and updates the translations accordingly.
  *
  * ## OPTIONS
  *
  * <project|url>
- * : Project path / ID or GitHub repository URL, e.g. https://github.com/wearerequired/required-valencia
+ * : Project path / ID or source code repository URL, e.g. https://github.com/wearerequired/required-valencia
+ *
+ * [--cached]
+ * : Used cached repository information and do not try to download code from remote.
  *
  * [--delete]
  * : Whether to first delete the existing local repository or not.
@@ -56,6 +59,7 @@ class UpdateCommand extends WP_CLI_Command {
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$delete  = get_flag_value( $assoc_args, 'delete', false );
+		$cached  = get_flag_value( $assoc_args, 'cached', false );
 		$locator = new ProjectLocator( $args[0] );
 		$project = $locator->get_project();
 
@@ -83,7 +87,7 @@ class UpdateCommand extends WP_CLI_Command {
 			$runner->delete_local_repository();
 		}
 
-		$success = $runner->run();
+		$success = $runner->run( $cached );
 
 		if ( $success ) {
 			WP_CLI::success( sprintf( 'Updated translations for project (ID: %d)!', $project->get_id() ) );

--- a/inc/CLI/UpdateCommand.php
+++ b/inc/CLI/UpdateCommand.php
@@ -30,6 +30,9 @@ class UpdateCommand extends WP_CLI_Command {
 	 * <project|url>
 	 * : Project path / ID or source code repository URL, e.g. https://github.com/wearerequired/required-valencia
 	 *
+	 * [--cached]
+	 * : Used cached repository information and do not try to download code from remote.
+	 *
 	 * [--delete]
 	 * : Whether to first delete the existing local repository or not.
 	 *

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -87,7 +87,7 @@ class Runner {
 
 		$local_repository = $cached ? $this->loader->get_local_path() : $this->loader->download();
 
-		if ( ! $local_repository ) {
+		if ( ! $local_repository || ! is_dir( $local_repository ) ) {
 			$this->updater->remove_lock();
 
 			return false;

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -71,20 +71,21 @@ class Runner {
 	}
 
 	/**
-	 * Fetches the GitHub repository and updates the translations based on the source code.
+	 * Updates the project's translations based on the source code.
 	 *
 	 * @since 3.0.0
 	 *
+	 * @param bool $cached Whether to use cached source code instead of updated one.
 	 * @return bool True on success, false otherwise.
 	 */
-	public function run() : bool {
+	public function run( $cached = false ): bool {
 		if ( $this->updater->has_lock() ) {
 			return false;
 		}
 
 		$this->updater->add_lock();
 
-		$local_repository = $this->loader->download();
+		$local_repository = $cached ? $this->loader->get_local_path() : $this->loader->download();
 
 		if ( ! $local_repository ) {
 			$this->updater->remove_lock();

--- a/tests/phpunit/tests/Runner.php
+++ b/tests/phpunit/tests/Runner.php
@@ -82,13 +82,14 @@ class Runner extends GP_UnitTestCase {
 		$this->assertFileExists( $this->loader->get_local_path() . '/foo.txt' );
 	}
 
-	public function test_run(): void {
+	public function test_run_missing_local_repository(): void {
 		$result = $this->runner->run();
 
-		$this->assertTrue( $result );
+		$this->assertFalse( $result );
 	}
 
 	public function test_run_with_existing_repository(): void {
+		mkdir( $this->loader->get_local_path() );
 		$result1 = $this->runner->run();
 		$result2 = $this->runner->run();
 
@@ -98,10 +99,10 @@ class Runner extends GP_UnitTestCase {
 
 	public function test_run_and_delete_existing_repository(): void {
 		$result1 = $this->runner->run();
-		$this->runner->delete_local_repository();
+		mkdir( $this->loader->get_local_path() );
 		$result2 = $this->runner->run();
 
-		$this->assertTrue( $result1 );
+		$this->assertFalse( $result1 );
 		$this->assertTrue( $result2 );
 	}
 
@@ -126,5 +127,24 @@ class Runner extends GP_UnitTestCase {
 		$result = $this->runner->run();
 
 		$this->assertFalse( $result );
+	}
+
+	public function test_run_cached_missing_local_repository(): void {
+		$result = $this->runner->run( true );
+		$this->assertFalse( $result );
+	}
+
+	public function test_run_cached_does_not_download_repository(): void {
+		$test_path = get_temp_dir() . 'traduttore-test-dir';
+
+		$loader = $this->createMock( Loader::class );
+		$loader->expects( $this->once() )->method( 'get_local_path' )->willReturn( $test_path );
+		$loader->expects( $this->never() )->method( 'download' )->willReturn( false );
+
+		mkdir( $loader->get_local_path() );
+
+		$result = $this->runner->run( true );
+
+		$this->assertTrue( $result );
 	}
 }

--- a/tests/phpunit/tests/Runner.php
+++ b/tests/phpunit/tests/Runner.php
@@ -18,7 +18,7 @@ use \Required\Traduttore\Loader\Git as Loader;
  */
 class Runner extends GP_UnitTestCase {
 	/**
-	 * @var P
+	 * @var Project
 	 */
 	protected $project;
 
@@ -28,7 +28,7 @@ class Runner extends GP_UnitTestCase {
 	protected $runner;
 
 	/**
-	 * @var Git
+	 * @var \Required\Traduttore\Loader
 	 */
 	protected $loader;
 


### PR DESCRIPTION
**Description**
As the title says, this change adds support for a `--cached` flag to the update command.

Fixes #79.

**How has this been tested?**
Manual testing + unit test coverage.

**Types of changes**
Extends `UpdateCommand` and `Runner::run()` to skip downloading the remote repository and instead use the local one.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
