### PR TITLE
Add new info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added new REST API route for incoming webhooks (`traduttore/v1/incoming-webhook`) which replaces the deprecated route (`github-webhook/v1/push-event`)
 * Changed all filters and actions to use `.` as the separator between the prefix and hook name instead of `_`
 * Improved scheduling of cron events to reduce number of unnecessary builds and updates
+* Added new `wp traduttore info` CLI command
 * Greatly improved documentation
 
 ## 2.0.3

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,3 +33,13 @@ If this local repository somehow gets broken, you can remove it via WP-CLI as fo
 ```bash
 wp traduttore cache clear <project|repository_url>
 ````
+
+## Show various details about the environment
+
+There's a command to print some helpful debug information about Traduttore.
+
+This includes things like the plugin version and path to the cache directory.
+
+```bash
+wp traduttore info
+```

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -40,7 +40,7 @@ use WP_CLI_Command;
  *     Subversion binary path: (not found)
  *     Cache directory:        /var/www/network.required.com/wordpress/content/traduttore
  *
- * @since 2.0.0
+ * @since 3.0.0
  */
 class InfoCommand extends WP_CLI_Command {
 	/**

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -33,6 +33,7 @@ use WP_CLI_Command;
  *     $ wp traduttore info
  *     Traduttore version:     3.0.0-alpha
  *     WordPress version:      4.9.8
+ *     GlotPress version:      2.3.1
  *     WP-CLI version:         2.0.1
  *     WP-CLI binary path:     /usr/local/bin/wp
  *     Git binary path:        /usr/bin/git
@@ -56,6 +57,7 @@ class InfoCommand extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$plugin_version = \Required\Traduttore\VERSION;
 		$wp_version     = get_bloginfo( 'version' );
+		$gp_version     = GP_VERSION;
 
 		$wp_cli_version = WP_CLI_VERSION;
 		$git_binary     = $this->get_git_binary_path();
@@ -68,6 +70,7 @@ class InfoCommand extends WP_CLI_Command {
 			$info = array(
 				'traduttore_version' => $plugin_version,
 				'wp_version'         => $wp_version,
+				'gp_version'         => $gp_version,
 				'wp_cli_version'     => $wp_cli_version,
 				'wp_cli_path'        => $wp_cli_binary,
 				'git_path'           => $git_binary,
@@ -80,6 +83,7 @@ class InfoCommand extends WP_CLI_Command {
 		} else {
 			WP_CLI::line( "Traduttore version:\t" . $plugin_version );
 			WP_CLI::line( "WordPress version:\t" . $wp_version );
+			WP_CLI::line( "GlotPress version:\t" . $gp_version );
 			WP_CLI::line( "WP-CLI version:\t\t" . $wp_cli_version );
 			WP_CLI::line( "WP-CLI binary path:\t" . $wp_cli_binary );
 			WP_CLI::line( "Git binary path:\t" . ( $git_binary ?: '(not found)' ) );

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -38,7 +38,7 @@ use WP_CLI_Command;
  *     Git binary path:        /usr/bin/git
  *     Mercurial binary path:  (not found)
  *     Subversion binary path: (not found)
- *     Cache directory:        /var/www/network.required.com/wordpress/content/traduttore
+ *     Cache directory:        /var/www/network.required.com/wp-content/traduttore
  *
  * @since 3.0.0
  */

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -31,14 +31,14 @@ use WP_CLI_Command;
  *
  *     # Display various data about the Traduttore environment
  *     $ wp traduttore info
- *     Traduttore version:	3.0.0-alpha
- *     WordPress version:	4.9.8
- *     WP-CLI version:		2.0.1
- *     WP-CLI binary path:	/usr/local/bin/wp
- *     Git binary path:	/usr/bin/git
- *     Mercurial binary path:	(not found)
- *     Subversion binary path:	(not found)
- *     Cache directory:	/var/www/network.required.com/wordpress/content/traduttore
+ *     Traduttore version:     3.0.0-alpha
+ *     WordPress version:      4.9.8
+ *     WP-CLI version:         2.0.1
+ *     WP-CLI binary path:     /usr/local/bin/wp
+ *     Git binary path:        /usr/bin/git
+ *     Mercurial binary path:  (not found)
+ *     Subversion binary path: (not found)
+ *     Cache directory:        /var/www/network.required.com/wordpress/content/traduttore
  *
  * @since 2.0.0
  */

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Command for printing various details about the environment.
+ *
+ * @since 3.0.0
+ *
+ * @package Required\Traduttore\CLI
+ */
+
+namespace Required\Traduttore\CLI;
+
+use Required\Traduttore\ZipProvider;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Print various details about the environment.
+ *
+ * ## OPTIONS
+ *
+ * [--format=<format>]
+ * : Render output in a particular format.
+ * ---
+ * default: list
+ * options:
+ *   - list
+ *   - json
+ * ---
+ *
+ * ## EXAMPLES
+ *
+ *     # Display various data about the Traduttore environment
+ *     $ wp traduttore info
+ *     OS:  Linux 4.10.0-42-generic #46~16.04.1-Ubuntu SMP Mon Dec 4 15:57:59 UTC 2017 x86_64
+ *     Shell:   /usr/bin/zsh
+ *     PHP binary:  /usr/bin/php
+ *     PHP version: 7.1.12-1+ubuntu16.04.1+deb.sury.org+1
+ *     php.ini used:    /etc/php/7.1/cli/php.ini
+ *     WP-CLI root dir:    phar://wp-cli.phar
+ *     WP-CLI packages dir:    /home/person/.wp-cli/packages/
+ *     WP-CLI global config:
+ *     WP-CLI project config:
+ *     WP-CLI version: 1.5.0
+ *
+ * @since 2.0.0
+ */
+class InfoCommand extends WP_CLI_Command {
+	/**
+	 * Class constructor.
+	 *
+	 * Automatically called by WP-CLI.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param array $args Command args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$plugin_version = \Required\Traduttore\VERSION;
+		$wp_version     = get_bloginfo( 'version' );
+
+		$wp_cli_version = WP_CLI_VERSION;
+		$git_binary     = $this->get_git_binary_path();
+		$hg_binary      = $this->get_hg_binary_path();
+		$svn_binary     = $this->get_svn_binary_path();
+		$wp_cli_binary  = $this->get_wp_binary_path();
+		$cache_dir      = ZipProvider::get_cache_dir();
+
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
+			$info = array(
+				'traduttore_version' => $plugin_version,
+				'wp_version'         => $wp_version,
+				'wp_cli_version'     => $wp_cli_version,
+				'wp_cli_path'        => $wp_cli_binary,
+				'git_path'           => $git_binary,
+				'hg_path'            => $hg_binary,
+				'svn_path'           => $svn_binary,
+				'cache_dir'          => $cache_dir,
+			);
+
+			WP_CLI::line( json_encode( $info ) );
+		} else {
+			WP_CLI::line( "Traduttore version:\t" . $plugin_version );
+			WP_CLI::line( "WordPress version:\t" . $wp_version );
+			WP_CLI::line( "WP-CLI version:\t" . $wp_cli_version );
+			WP_CLI::line( "WP-CLI binary path:\t" . $wp_cli_binary );
+			WP_CLI::line( "Git binary path:\t" . $git_binary );
+			WP_CLI::line( "Mercurial binary path:\t" . $hg_binary );
+			WP_CLI::line( "Subversion binary path:\t" . $svn_binary );
+			WP_CLI::line( "Cache directory:\t" . $cache_dir );
+		}
+	}
+
+	/**
+	 * Returns the path to the Git binary.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Binary path on success, null otherwise.
+	 */
+	protected function get_git_binary_path(): ?string {
+		exec(
+			escapeshellcmd( 'which git' ),
+			$output,
+			$status
+		);
+
+		return 0 === $status ? $output : null;
+	}
+
+	/**
+	 * Returns the path to the Mercurial binary.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Binary path on success, null otherwise.
+	 */
+	protected function get_hg_binary_path(): ?string {
+		exec(
+			escapeshellcmd( 'which hg' ),
+			$output,
+			$status
+		);
+
+		return 0 === $status ? $output : null;
+	}
+
+	/**
+	 * Returns the path to the Subversion binary.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Binary path on success, null otherwise.
+	 */
+	protected function get_svn_binary_path(): ?string {
+		exec(
+			escapeshellcmd( 'which svn' ),
+			$output,
+			$status
+		);
+
+		return 0 === $status ? $output : null;
+	}
+
+	/**
+	 * Returns the path to the WP-CLI binary.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Binary path on success, null otherwise.
+	 */
+	protected function get_wp_binary_path(): ?string {
+		if ( defined( 'TRADUTTORE_WP_BIN' ) && TRADUTTORE_WP_BIN ) {
+			return TRADUTTORE_WP_BIN;
+		}
+
+		exec(
+			escapeshellcmd( 'which wp' ),
+			$output,
+			$status
+		);
+
+		return 0 === $status ? $output : null;
+	}
+}

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -82,11 +82,11 @@ class InfoCommand extends WP_CLI_Command {
 		} else {
 			WP_CLI::line( "Traduttore version:\t" . $plugin_version );
 			WP_CLI::line( "WordPress version:\t" . $wp_version );
-			WP_CLI::line( "WP-CLI version:\t" . $wp_cli_version );
+			WP_CLI::line( "WP-CLI version:\t\t" . $wp_cli_version );
 			WP_CLI::line( "WP-CLI binary path:\t" . $wp_cli_binary );
-			WP_CLI::line( "Git binary path:\t" . $git_binary );
-			WP_CLI::line( "Mercurial binary path:\t" . $hg_binary );
-			WP_CLI::line( "Subversion binary path:\t" . $svn_binary );
+			WP_CLI::line( "Git binary path:\t" . ( $git_binary ?: '(not found)' ) );
+			WP_CLI::line( "Mercurial binary path:\t" . ( $hg_binary ?: '(not found)' ) );
+			WP_CLI::line( "Subversion binary path:\t" . ( $svn_binary ?: '(not found)' ) );
 			WP_CLI::line( "Cache directory:\t" . $cache_dir );
 		}
 	}
@@ -105,7 +105,7 @@ class InfoCommand extends WP_CLI_Command {
 			$status
 		);
 
-		return 0 === $status ? $output : null;
+		return 0 === $status ? $output[0] : null;
 	}
 
 	/**
@@ -122,7 +122,7 @@ class InfoCommand extends WP_CLI_Command {
 			$status
 		);
 
-		return 0 === $status ? $output : null;
+		return 0 === $status ? $output[0] : null;
 	}
 
 	/**
@@ -139,7 +139,7 @@ class InfoCommand extends WP_CLI_Command {
 			$status
 		);
 
-		return 0 === $status ? $output : null;
+		return 0 === $status ? $output[0] : null;
 	}
 
 	/**
@@ -160,6 +160,6 @@ class InfoCommand extends WP_CLI_Command {
 			$status
 		);
 
-		return 0 === $status ? $output : null;
+		return 0 === $status ? $output[0] : null;
 	}
 }

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -31,16 +31,14 @@ use WP_CLI_Command;
  *
  *     # Display various data about the Traduttore environment
  *     $ wp traduttore info
- *     OS:  Linux 4.10.0-42-generic #46~16.04.1-Ubuntu SMP Mon Dec 4 15:57:59 UTC 2017 x86_64
- *     Shell:   /usr/bin/zsh
- *     PHP binary:  /usr/bin/php
- *     PHP version: 7.1.12-1+ubuntu16.04.1+deb.sury.org+1
- *     php.ini used:    /etc/php/7.1/cli/php.ini
- *     WP-CLI root dir:    phar://wp-cli.phar
- *     WP-CLI packages dir:    /home/person/.wp-cli/packages/
- *     WP-CLI global config:
- *     WP-CLI project config:
- *     WP-CLI version: 1.5.0
+ *     Traduttore version:	3.0.0-alpha
+ *     WordPress version:	4.9.8
+ *     WP-CLI version:		2.0.1
+ *     WP-CLI binary path:	/usr/local/bin/wp
+ *     Git binary path:	/usr/bin/git
+ *     Mercurial binary path:	(not found)
+ *     Subversion binary path:	(not found)
+ *     Cache directory:	/var/www/network.required.com/wordpress/content/traduttore
  *
  * @since 2.0.0
  */

--- a/traduttore.php
+++ b/traduttore.php
@@ -43,6 +43,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Plugin' ) ) {
 	return;
 }
 
+define( __NAMESPACE__ . '\VERSION', '3.0.0-alpha' );
 define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 
 register_deactivation_hook( __FILE__, [ Plugin::class, 'on_plugin_deactivation' ] );
@@ -60,6 +61,7 @@ function init() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\init', 1 );
 
 if ( class_exists( '\WP_CLI' ) ) {
+	WP_CLI::add_command( 'traduttore info', CLI\InfoCommand::class );
 	WP_CLI::add_command( 'traduttore build', CLI\BuildCommand::class );
 	WP_CLI::add_command( 'traduttore cache', CLI\CacheCommand::class );
 	WP_CLI::add_command( 'traduttore update', CLI\UpdateCommand::class );


### PR DESCRIPTION
**Description**
Adds a new `wp traduttore info` command that prints various details about the environment, similar to `wp cli info`.

See #67.

**How has this been tested?**

Ran the command locally with the following output:

```bash
$ wp @translate-dev traduttore info
Traduttore version:	3.0.0-alpha
WordPress version:	4.9.8
GlotPress version:  2.3.1
WP-CLI version:		2.0.1
WP-CLI binary path:	/usr/local/bin/wp
Git binary path:	/usr/bin/git
Mercurial binary path:	(not found)
Subversion binary path:	(not found)
Cache directory:	/var/www/network.required.com/wordpress/content/traduttore
```

**Types of changes**

New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
