### PR TITLE
Set addUncoveredFilesFromWhitelist to false

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true">
+		<whitelist addUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">inc</directory>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
**Description**

This fixes an issue where the files for the CLI commands are wrongly included in PHPUnit code coverage reports. That's one of the reasons why the code coverage is so low.

These commands should not be tested via PHPUnit, but with Behat tests instead.

By setting `addUncoveredFilesFromWhitelist` to `false` the CLI command classes are excluded from code coverage reports.

An alternative would be to explicitly exclude these files so that other files don't slip under the radar. But since only CLI files are affected and since we generally strive to have good coverage everywhere else, I think this should be fine.

**How has this been tested?**
By running this PR :-)

**Types of changes**
Bug fix in the code coverage reporting.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
