### PR TITLE
Run "composer normalize" in lint stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,11 @@ jobs:
   fast_finish: true
   include:
     - stage: lint
+      before_script:
+        - composer global require localheinz/composer-normalize
       script:
         - composer lint
+        - composer normalize --dry-run
     - stage: coverage
       before_install: skip
       script:


### PR DESCRIPTION
**Description**

By running `composer normalize` in the lint stage of the tests we can ensure that the comoposer file meets certain criteria, reducing the risk of merge conflicts because of reordering or anything.

Fixes #97.

**How has this been tested?**

Tests on Travis CI :-)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
