### PR TITLE
Update documentation with improvements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # REST API
 
-Traduttore adds new routes to both the WordPress REST API as well as the API provided by GlotPress.
+Traduttore adds new routes to both the WordPress REST API (https://example.com/wp-json) as well as the API provided by GlotPress.
 
 ## API Endpoints
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -23,13 +23,13 @@ Here's an example of how you can use `add_project()` in your plugin or theme:
 ```php
 \Required\Traduttore_Registry\add_project(
 	'plugin',
-	'example-plugin',
+	'acme-plugin',
 	'https://<home-url>/api/translations/acme/acme-plugin/'
 );
 
 \Required\Traduttore_Registry\add_project(
 	'theme',
-	'example-theme',
+	'acme-theme',
 	'https://<home-url>/api/translations/acme/acme-theme/'
 );
 ```


### PR DESCRIPTION
**Description**
- Document that default WP REST API URL.
- The plugin text-domain should match the project slug. That is what I noticed today morning. It would be good for someone else to double check this.
