### PR TITLE
Improve repository name extraction from source url template

### DIFF
--- a/inc/Repository/Bitbucket.php
+++ b/inc/Repository/Bitbucket.php
@@ -64,16 +64,12 @@ class Bitbucket extends Base {
 
 			if ( ! $url ) {
 				$url = $this->project->get_source_url_template();
-
-				if ( false !== strpos( $url, '/src/' ) ) {
-					$parts = explode( '/src/', $url );
-					$url   = array_shift( $parts );
-				}
 			}
 
 			if ( $url ) {
-				$path = wp_parse_url( $url, PHP_URL_PATH );
-				$name = trim( $path, '/' );
+				$path  = trim( wp_parse_url( $url, PHP_URL_PATH ), '/' );
+				$parts = explode( '/', $path );
+				$name  = implode( '/', array_splice( $parts, 0, 2 ) );
 			}
 		}
 

--- a/inc/Repository/GitHub.php
+++ b/inc/Repository/GitHub.php
@@ -64,16 +64,12 @@ class GitHub extends Base {
 
 			if ( ! $url ) {
 				$url = $this->project->get_source_url_template();
-
-				if ( false !== strpos( $url, '/blob/' ) ) {
-					$parts = explode( '/blob/', $url );
-					$url   = array_shift( $parts );
-				}
 			}
 
 			if ( $url ) {
-				$path = wp_parse_url( $url, PHP_URL_PATH );
-				$name = trim( $path, '/' );
+				$path  = trim( wp_parse_url( $url, PHP_URL_PATH ), '/' );
+				$parts = explode( '/', $path );
+				$name  = implode( '/', array_splice( $parts, 0, 2 ) );
 			}
 		}
 

--- a/inc/Repository/GitLab.php
+++ b/inc/Repository/GitLab.php
@@ -70,16 +70,13 @@ class GitLab extends Base {
 
 			if ( ! $url ) {
 				$url = $this->project->get_source_url_template();
-
-				if ( false !== strpos( $url, '/blob/' ) ) {
-					$parts = explode( '/blob/', $url );
-					$url   = array_shift( $parts );
-				}
 			}
 
 			if ( $url ) {
-				$path = wp_parse_url( $url, PHP_URL_PATH );
-				$name = trim( $path, '/' );
+				// Assumes that GitLab is not running in a sub folder.
+				$path  = trim( wp_parse_url( $url, PHP_URL_PATH ), '/' );
+				$parts = explode( '/', $path );
+				$name  = implode( '/', array_splice( $parts, 0, 2 ) );
 			}
 		}
 

--- a/tests/phpunit/tests/Repository/Bitbucket.php
+++ b/tests/phpunit/tests/Repository/Bitbucket.php
@@ -53,9 +53,16 @@ class Bitbucket extends GP_UnitTestCase {
 	}
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
-		$this->project->get_project()->source_url_template = 'https://bitbucket.org/wearerequired/traduttore/src/master/%file%#L%line%';
+		$project = new Project(
+			$this->factory->project->create(
+				[
+					'name'                => 'Project',
+					'source_url_template' => 'https://bitbucket.org/wearerequired/traduttore/src/master/%file%#L%line%',
+				]
+			)
+		);
 
-		$repository = new BitbucketRepository( $this->project );
+		$repository = new BitbucketRepository( $project );
 
 		$this->assertSame( 'wearerequired/traduttore', $repository->get_name() );
 	}

--- a/tests/phpunit/tests/Repository/GitHub.php
+++ b/tests/phpunit/tests/Repository/GitHub.php
@@ -53,9 +53,31 @@ class GitHub extends GP_UnitTestCase {
 	}
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
-		$this->project->get_project()->source_url_template = 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%';
+		$project = new Project(
+			$this->factory->project->create(
+				[
+					'name'                => 'Project',
+					'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
+				]
+			)
+		);
 
-		$repository = new GitHubRepository( $this->project );
+		$repository = new GitHubRepository( $project );
+
+		$this->assertSame( 'wearerequired/traduttore', $repository->get_name() );
+	}
+
+	public function test_get_name_falls_back_to_different_source_url_template(): void {
+		$project = new Project(
+			$this->factory->project->create(
+				[
+					'name'                => 'Project',
+					'source_url_template' => 'https://github.com/wearerequired/traduttore/tree/master/%file%#L%line%',
+				]
+			)
+		);
+
+		$repository = new GitHubRepository( $project );
 
 		$this->assertSame( 'wearerequired/traduttore', $repository->get_name() );
 	}

--- a/tests/phpunit/tests/Repository/GitLab.php
+++ b/tests/phpunit/tests/Repository/GitLab.php
@@ -53,9 +53,16 @@ class GitLab extends GP_UnitTestCase {
 	}
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
-		$this->project->get_project()->source_url_template = 'https://gitlab.com/wearerequired/traduttore/blob/master/%file%#L%line%';
+		$project = new Project(
+			$this->factory->project->create(
+				[
+					'name'                => 'Project',
+					'source_url_template' => 'https://gitlab.com/wearerequired/traduttore/blob/master/%file%#L%line%',
+				]
+			)
+		);
 
-		$repository = new GitLabRepository( $this->project );
+		$repository = new GitLabRepository( $project );
 
 		$this->assertSame( 'wearerequired/traduttore', $repository->get_name() );
 	}


### PR DESCRIPTION
**Description**
Fixes an issue where the parts after the repository name weren't removed.

Without this change, the repository name (`wearerequired/traduttore`) isn't being correctly derived from the source url template (`https://github.com/wearerequired/traduttore/tree/master/%file%#L%line%`).

**How has this been tested?**
Updated unit tests accordingly.

**Types of changes**
Nice little bug fix!

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
