### PR TITLE
Add Jekyll config to use Just the Docs theme

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/_config.yml export-ignore
 /phpcs.xml.dist export-ignore
 /phpunit.xml.dist export-ignore

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+remote_theme: pmarsceill/just-the-docs


### PR DESCRIPTION
Not sure if this is enough but apparently this would configure Jekyll to use the [Just the Docs](https://pmarsceill.github.io/just-the-docs/) theme for GitHub Pages.