### PR TITLE
Store last updated time in database

### DIFF
--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -49,6 +49,7 @@ class ProjectCommand extends WP_CLI_Command {
 	 *     Project name:          Foo Project
 	 *     Project slug:          foo
 	 *     Text domain:           foo-plugin
+	 *     Last updated:          2018-11-11 11:11:11
 	 *     Repository Cache:      /tmp/traduttore-github.com-wearerequired-foo
 	 *     Repository URL:        (unknown)
 	 *     Repository Type:       github
@@ -79,6 +80,7 @@ class ProjectCommand extends WP_CLI_Command {
 		$project_name          = $project->get_name();
 		$project_slug          = $project->get_slug();
 		$project_text_domain   = $project->get_text_domain();
+		$last_updated          = $project->get_last_updated_time();
 		$local_path            = $loader ? $loader->get_local_path() : '';
 		$repository_url        = $project->get_repository_url() ?? '(unknown)';
 		$repository_type       = $repository ? $repository->get_type() : $project->get_repository_type();
@@ -87,7 +89,7 @@ class ProjectCommand extends WP_CLI_Command {
 		$repository_ssh_url    = $repository ? $repository->get_ssh_url() : '(unknown)';
 		$repository_https_url  = $repository ? $repository->get_https_url() : '(unknown)';
 		$repository_instance   = $repository ? get_class( $repository ) : '(unknown)';
-		$loader_instance       = $loader ? get_class( $loader ) : '';
+		$loader_instance       = $loader ? get_class( $loader ) : '(unknown)';
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = array(
@@ -95,6 +97,7 @@ class ProjectCommand extends WP_CLI_Command {
 				'name'                  => $project_name,
 				'slug'                  => $project_slug,
 				'text_domain'           => $project_text_domain,
+				'last_updated'          => $last_updated,
 				'repository_cache'      => $local_path,
 				'repository_url'        => $repository_url,
 				'repository_type'       => $repository_type,
@@ -112,6 +115,7 @@ class ProjectCommand extends WP_CLI_Command {
 			WP_CLI::line( "Project name:\t\t" . $project_name );
 			WP_CLI::line( "Project slug:\t\t" . $project_slug );
 			WP_CLI::line( "Text domain:\t\t" . $project_text_domain );
+			WP_CLI::line( "Last updated:\t\t" . $last_updated );
 			WP_CLI::line( "Repository Cache:\t" . $local_path );
 			WP_CLI::line( "Repository URL:\t\t" . $repository_url );
 			WP_CLI::line( "Repository Type:\t" . $repository_type );

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -99,6 +99,15 @@ class Project {
 	protected const TEXT_DOMAIN_KEY = '_traduttore_text_domain';
 
 	/**
+	 * Last update time meta key.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string Last update meta key.
+	 */
+	protected const UPDATE_TIME_KEY = '_traduttore_update_time';
+
+	/**
 	 * GlotPress project.
 	 *
 	 * @since 3.0.0
@@ -396,5 +405,30 @@ class Project {
 	 */
 	public function set_text_domain( string $name ): bool {
 		return (bool) gp_update_meta( $this->project->id, static::TEXT_DOMAIN_KEY, $name, 'project' );
+	}
+
+	/**
+	 * Returns the time for when the project was last updated.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Last updated time if stored, null otherwise.
+	 */
+	public function get_last_updated_time(): ?string {
+		$time = gp_get_meta( 'project', $this->project->id, static::UPDATE_TIME_KEY );
+
+		return $time ?: null;
+	}
+
+	/**
+	 * Updates the time for when the project was last updated.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $time The new updated time.
+	 * @return bool Whether the data was successfully saved or not.
+	 */
+	public function set_last_updated_time( string $time ): bool {
+		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, $time, 'project' );
 	}
 }

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -9,6 +9,8 @@
 
 namespace Required\Traduttore;
 
+use DateTime;
+use DateTimeZone;
 use GP;
 use PO;
 
@@ -130,6 +132,10 @@ class Updater {
 		$this->project->set_text_domain( sanitize_text_field( $translations->headers['X-Domain'] ) );
 
 		$stats = GP::$original->import_for_project( $this->project->get_project(), $translations );
+
+		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+		$this->project->set_last_updated_time( $now->format( DATE_MYSQL ) );
 
 		/**
 		 * Fires after translations have been updated.

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -146,4 +146,16 @@ class Project extends GP_UnitTestCase {
 
 		$this->assertSame( $url, $this->project->get_repository_https_url() );
 	}
+
+	public function test_get_last_updated_time_returns_null_if_missing(): void {
+		$this->assertNull( $this->project->get_repository_https_url() );
+	}
+
+	public function test_get_last_updated_time(): void {
+		$time = date( DATE_MYSQL );
+
+		$this->project->set_last_updated_time( $time );
+
+		$this->assertSame( $time, $this->project->get_last_updated_time() );
+	}
 }

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -53,6 +53,7 @@ class Updater extends GP_UnitTestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'foo-plugin', $this->project->get_text_domain() );
+		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 
 	public function test_update_with_composer_config(): void {
@@ -65,6 +66,7 @@ class Updater extends GP_UnitTestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'baz', $this->project->get_text_domain() );
+		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 
 	public function test_update_with_config_file(): void {
@@ -77,6 +79,7 @@ class Updater extends GP_UnitTestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'foo', $this->project->get_text_domain() );
+		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 
 	public function test_has_no_lock_initially(): void {


### PR DESCRIPTION
**Description**

This changes the updater so that after every string import Traduttore stores that time in the database.

Makes debugging a bit easier.

Fixes #114.


**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
