### PR TITLE
Override existing ZIP files upon generation

### DIFF
--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -144,7 +144,9 @@ class ZipProvider {
 
 		$zip = new ZipArchive();
 
-		if ( $zip->open( $this->get_zip_path(), ZipArchive::CREATE ) === true ) {
+		$temp_zip_file = wp_tempnam( $this->get_zip_filename() );
+
+		if ( $zip->open( $temp_zip_file, ZipArchive::CREATE ) === true ) {
 			foreach ( $files_for_zip as $temp_file => $file_name ) {
 				$zip->addFile( $temp_file, $file_name );
 			}
@@ -152,8 +154,10 @@ class ZipProvider {
 			$zip->close();
 		}
 
+		$wp_filesystem->move( $temp_zip_file, $this->get_zip_path(), true );
+
 		foreach ( $files_for_zip as $temp_file => $file_name ) {
-			unlink( $temp_file );
+			$wp_filesystem->delete( $temp_file );
 		}
 
 		gp_update_meta( $this->translation_set->id, static::BUILD_TIME_KEY, $this->translation_set->last_modified(), 'translation_set' );

--- a/tests/phpunit/tests/ZipProvider.php
+++ b/tests/phpunit/tests/ZipProvider.php
@@ -158,6 +158,40 @@ class ZipProvider extends TestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test_replaces_existing_zip_file(): void {
+		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+
+		$this->factory->translation->create(
+			[
+				'original_id'        => $original->id,
+				'translation_set_id' => $this->translation_set->id,
+				'status'             => 'current',
+			]
+		);
+
+		$provider = new Provider( $this->translation_set );
+
+		$provider->generate_zip_file();
+
+		$zip_before = new ZipArchive();
+		$zip_before->open( $provider->get_zip_path() );
+		$zip_before->addFromString( 'foo.txt', 'bar' );
+
+		$file_before = $zip_before->statName( 'foo.txt' );
+
+		$zip_before->close();
+
+		$provider->generate_zip_file();
+
+		$zip_after = new ZipArchive();
+		$zip_after->open( $provider->get_zip_path() );
+
+		$file_after = $zip_after->statName( 'foo.txt' );
+
+		$this->assertInternalType( 'array', $file_before );
+		$this->assertFalse( $file_after );
+	}
+
 	public function test_get_last_build_time_after_zip_generation(): void {
 		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 


### PR DESCRIPTION
**Description**
Fixes #131 by overriding any existing ZIP files when generating new ones.

**How has this been tested?**
This PR adds a unit test for this.

**Types of changes**
Bug fix.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
