### PR TITLE
Use project version inferred from POT import for translation API

### DIFF
--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -48,6 +48,7 @@ class ProjectCommand extends WP_CLI_Command {
 	 *     Project ID:            1
 	 *     Project name:          Foo Project
 	 *     Project slug:          foo
+	 *     Version:               1.0.1
 	 *     Text domain:           foo-plugin
 	 *     Last updated:          2018-11-11 11:11:11
 	 *     Repository Cache:      /tmp/traduttore-github.com-wearerequired-foo
@@ -79,6 +80,7 @@ class ProjectCommand extends WP_CLI_Command {
 		$project_id            = $project->get_id();
 		$project_name          = $project->get_name();
 		$project_slug          = $project->get_slug();
+		$project_version       = $project->get_version();
 		$project_text_domain   = $project->get_text_domain();
 		$last_updated          = $project->get_last_updated_time();
 		$local_path            = $loader ? $loader->get_local_path() : '';
@@ -92,10 +94,11 @@ class ProjectCommand extends WP_CLI_Command {
 		$loader_instance       = $loader ? get_class( $loader ) : '(unknown)';
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
-			$info = array(
+			$info = [
 				'id'                    => $project_id,
 				'name'                  => $project_name,
 				'slug'                  => $project_slug,
+				'version'               => $project_version,
 				'text_domain'           => $project_text_domain,
 				'last_updated'          => $last_updated,
 				'repository_cache'      => $local_path,
@@ -107,13 +110,14 @@ class ProjectCommand extends WP_CLI_Command {
 				'repository_https_url'  => $repository_https_url,
 				'repository_instance'   => $repository_instance,
 				'loader_instance'       => $loader_instance,
-			);
+			];
 
 			WP_CLI::line( json_encode( $info ) );
 		} else {
 			WP_CLI::line( "Project ID:\t\t" . $project_id );
 			WP_CLI::line( "Project name:\t\t" . $project_name );
 			WP_CLI::line( "Project slug:\t\t" . $project_slug );
+			WP_CLI::line( "Version:\t\t" . $project_version );
 			WP_CLI::line( "Text domain:\t\t" . $project_text_domain );
 			WP_CLI::line( "Last updated:\t\t" . $last_updated );
 			WP_CLI::line( "Repository Cache:\t" . $local_path );

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -108,6 +108,15 @@ class Project {
 	protected const UPDATE_TIME_KEY = '_traduttore_update_time';
 
 	/**
+	 * Version number meta key.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string Version number meta key.
+	 */
+	protected const VERSION_KEY = '_traduttore_version';
+
+	/**
 	 * GlotPress project.
 	 *
 	 * @since 3.0.0
@@ -430,5 +439,30 @@ class Project {
 	 */
 	public function set_last_updated_time( string $time ): bool {
 		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, $time, 'project' );
+	}
+
+	/**
+	 * Returns the project's version number.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return null|string Version number if stored, null otherwise.
+	 */
+	public function get_version(): ?string {
+		$time = gp_get_meta( 'project', $this->project->id, static::VERSION_KEY );
+
+		return $time ?: null;
+	}
+
+	/**
+	 * Updates the project's version number.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $version The new version number.
+	 * @return bool Whether the data was successfully saved or not.
+	 */
+	public function set_version( string $version ): bool {
+		return (bool) gp_update_meta( $this->project->id, static::VERSION_KEY, $version, 'project' );
 	}
 }

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -449,9 +449,9 @@ class Project {
 	 * @return null|string Version number if stored, null otherwise.
 	 */
 	public function get_version(): ?string {
-		$time = gp_get_meta( 'project', $this->project->id, static::VERSION_KEY );
+		$version = gp_get_meta( 'project', $this->project->id, static::VERSION_KEY );
 
-		return $time ?: null;
+		return $version ?: null;
 	}
 
 	/**

--- a/inc/TranslationApiRoute.php
+++ b/inc/TranslationApiRoute.php
@@ -32,14 +32,17 @@ class TranslationApiRoute extends GP_Route_Main {
 		$this->header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
 
 		// Get the project object from the project path that was passed in.
-		$project = GP::$project->by_path( $project_path );
-		if ( ! $project ) {
+		$gp_project = GP::$project->by_path( $project_path );
+
+		if ( ! $gp_project ) {
 			$this->status_header( 404 );
 			echo wp_json_encode( [ 'error' => 'Project not found.' ] );
 			return;
 		}
 
-		$translation_sets = (array) GP::$translation_set->by_project_id( $project->id );
+		$project = new Project( $gp_project );
+
+		$translation_sets = (array) GP::$translation_set->by_project_id( $project->get_id() );
 
 		$result = [];
 
@@ -56,7 +59,7 @@ class TranslationApiRoute extends GP_Route_Main {
 
 			$result[] = [
 				'language'     => $locale->wp_locale,
-				'version'      => '1.0',
+				'version'      => $project->get_version() ?? '1.0',
 				'updated'      => $zip_provider->get_last_build_time(),
 				'english_name' => $locale->english_name,
 				'native_name'  => $locale->native_name,

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -131,6 +131,10 @@ class Updater {
 
 		$this->project->set_text_domain( sanitize_text_field( $translations->headers['X-Domain'] ) );
 
+		if ( $translations->headers['Project-Id-Version'] ) {
+			$this->project->set_version( $this->extract_version( $translations->headers['Project-Id-Version'] ) );
+		}
+
 		$stats = GP::$original->import_for_project( $this->project->get_project(), $translations );
 
 		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
@@ -149,6 +153,24 @@ class Updater {
 		do_action( 'traduttore.updated', $this->project, $stats, $translations );
 
 		return true;
+	}
+
+	/**
+	 * Extracts the version number from the Project-Id-Version POT header.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $project_id_version Project-Id-Version header string.
+	 * @return null|string Version number on success, null otherwise.
+	 */
+	protected function extract_version( string $project_id_version ): ?string {
+		if ( false === strpos( $project_id_version, ' ' ) ) {
+			return null;
+		}
+
+		$parts = explode( ' ', $project_id_version );
+
+		return array_pop( $parts );
 	}
 
 	/**

--- a/tests/phpunit/data/example-with-composer/myplugin.php
+++ b/tests/phpunit/data/example-with-composer/myplugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Foo Plugin
  * Plugin URI:  https://example.com
  * Description:
- * Version:     0.1.0
+ * Version:     1.0.0
  * Author:
  * Author URI:
  * License:     GPL-2.0+

--- a/tests/phpunit/data/example-with-config/myplugin.php
+++ b/tests/phpunit/data/example-with-config/myplugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Foo Plugin
  * Plugin URI:  https://example.com
  * Description:
- * Version:     0.1.0
+ * Version:     1.2.3-beta5
  * Author:
  * Author URI:
  * License:     GPL-2.0+

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -165,4 +165,12 @@ class Project extends TestCase {
 
 		$this->assertSame( $secret, $this->project->get_repository_webhook_secret() );
 	}
+
+	public function test_get_version(): void {
+		$version = '1.2.3';
+
+		$this->project->set_version( $version );
+
+		$this->assertSame( $version, $this->project->get_version() );
+	}
 }

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -52,6 +52,7 @@ class Updater extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'foo-plugin', $this->project->get_text_domain() );
+		$this->assertSame( '0.1.0', $this->project->get_version() );
 		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 
@@ -65,6 +66,7 @@ class Updater extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'baz', $this->project->get_text_domain() );
+		$this->assertSame( '1.0.0', $this->project->get_version() );
 		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 
@@ -78,6 +80,7 @@ class Updater extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( $originals );
 		$this->assertSame( 'foo', $this->project->get_text_domain() );
+		$this->assertSame( '1.2.3-beta5', $this->project->get_version() );
 		$this->assertNotEmpty( $this->project->get_last_updated_time() );
 	}
 


### PR DESCRIPTION
**Description**

Extracts and stores the version number from the `Project-Id-Version` header if it exists in a POT file.

The version number is then used in the translation API responses.

**How has this been tested?**

Added unit tests to document the behavior.

**Types of changes**
New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
