### PR TITLE
Fix/update time timezone

### DIFF
--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -82,7 +82,7 @@ class ProjectCommand extends WP_CLI_Command {
 		$project_slug          = $project->get_slug();
 		$project_version       = $project->get_version();
 		$project_text_domain   = $project->get_text_domain();
-		$last_updated          = $project->get_last_updated_time();
+		$last_updated          = $project->get_last_updated_time() ? $project->get_last_updated_time()->format( DATE_ATOM ) : '';
 		$local_path            = $loader ? $loader->get_local_path() : '';
 		$repository_url        = $project->get_repository_url() ?? '(unknown)';
 		$repository_type       = $repository ? $repository->get_type() : $project->get_repository_type();

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -9,6 +9,7 @@
 
 namespace Required\Traduttore;
 
+use DateTime;
 use GP_Project;
 
 /**
@@ -421,12 +422,12 @@ class Project {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return null|string Last updated time if stored, null otherwise.
+	 * @return null|DateTime Last updated time if stored, null otherwise.
 	 */
-	public function get_last_updated_time(): ?string {
+	public function get_last_updated_time(): ?DateTime {
 		$time = gp_get_meta( 'project', $this->project->id, static::UPDATE_TIME_KEY );
 
-		return $time ?: null;
+		return $time ? new DateTime( $time ) : null;
 	}
 
 	/**
@@ -438,7 +439,7 @@ class Project {
 	 * @return bool Whether the data was successfully saved or not.
 	 */
 	public function set_last_updated_time( string $time ): bool {
-		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, $time, 'project' );
+		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, ( new DateTime( $time ) )->format( DATE_ATOM ), 'project' );
 	}
 
 	/**

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -10,6 +10,7 @@
 namespace Required\Traduttore;
 
 use DateTime;
+use DateTimeZone;
 use GP_Project;
 
 /**
@@ -427,7 +428,7 @@ class Project {
 	public function get_last_updated_time(): ?DateTime {
 		$time = gp_get_meta( 'project', $this->project->id, static::UPDATE_TIME_KEY );
 
-		return $time ? new DateTime( $time ) : null;
+		return $time ? new DateTime( $time, new DateTimeZone( 'UTC' ) ) : null;
 	}
 
 	/**
@@ -435,11 +436,11 @@ class Project {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $time The new updated time.
+	 * @param DateTime $time The new updated time.
 	 * @return bool Whether the data was successfully saved or not.
 	 */
-	public function set_last_updated_time( string $time ): bool {
-		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, ( new DateTime( $time ) )->format( DATE_ATOM ), 'project' );
+	public function set_last_updated_time( DateTime $time ): bool {
+		return (bool) gp_update_meta( $this->project->id, static::UPDATE_TIME_KEY, $time->format( DATE_ATOM ), 'project' );
 	}
 
 	/**

--- a/inc/TranslationApiRoute.php
+++ b/inc/TranslationApiRoute.php
@@ -9,6 +9,7 @@
 
 namespace Required\Traduttore;
 
+use DateTime;
 use GP;
 use GP_Locale;
 use GP_Locales;
@@ -60,7 +61,7 @@ class TranslationApiRoute extends GP_Route_Main {
 			$result[] = [
 				'language'     => $locale->wp_locale,
 				'version'      => $project->get_version() ?? '1.0',
-				'updated'      => $zip_provider->get_last_build_time(),
+				'updated'      => ( new DateTime( $zip_provider->get_last_build_time() ) )->format( DATE_ATOM ),
 				'english_name' => $locale->english_name,
 				'native_name'  => $locale->native_name,
 				'package'      => $zip_provider->get_zip_url(),

--- a/inc/TranslationApiRoute.php
+++ b/inc/TranslationApiRoute.php
@@ -61,7 +61,7 @@ class TranslationApiRoute extends GP_Route_Main {
 			$result[] = [
 				'language'     => $locale->wp_locale,
 				'version'      => $project->get_version() ?? '1.0',
-				'updated'      => ( new DateTime( $zip_provider->get_last_build_time() ) )->format( DATE_ATOM ),
+				'updated'      => $zip_provider->get_last_build_time()->format( DATE_ATOM ),
 				'english_name' => $locale->english_name,
 				'native_name'  => $locale->native_name,
 				'package'      => $zip_provider->get_zip_url(),

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -139,7 +139,7 @@ class Updater {
 
 		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->project->set_last_updated_time( $now->format( DATE_MYSQL ) );
+		$this->project->set_last_updated_time( $now->format( DATE_ATOM ) );
 
 		/**
 		 * Fires after translations have been updated.

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -137,9 +137,7 @@ class Updater {
 
 		$stats = GP::$original->import_for_project( $this->project->get_project(), $translations );
 
-		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-
-		$this->project->set_last_updated_time( $now->format( DATE_ATOM ) );
+		$this->project->set_last_updated_time( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
 
 		/**
 		 * Fires after translations have been updated.

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -9,6 +9,7 @@
 
 namespace Required\Traduttore;
 
+use DateTime;
 use GP;
 use GP_Locale;
 use GP_Locales;
@@ -213,12 +214,12 @@ class ZipProvider {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return string Last build time.
+	 * @return DateTime Last build time.
 	 */
-	public function get_last_build_time() :? string {
+	public function get_last_build_time() :? DateTime {
 		$meta = gp_get_meta( 'translation_set', $this->translation_set->id, static::BUILD_TIME_KEY );
 
-		return $meta ?: null;
+		return $meta ? new DateTime( $meta ) : null;
 	}
 
 	/**

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -10,6 +10,7 @@
 namespace Required\Traduttore;
 
 use DateTime;
+use DateTimeZone;
 use GP;
 use GP_Locale;
 use GP_Locales;
@@ -140,7 +141,15 @@ class ZipProvider {
 			$wp_filesystem->delete( $temp_file );
 		}
 
-		gp_update_meta( $this->translation_set->id, static::BUILD_TIME_KEY, $this->translation_set->last_modified(), 'translation_set' );
+		$last_modified = $this->translation_set->last_modified();
+
+		if ( $last_modified ) {
+			$last_modified = new DateTime( $last_modified, new DateTimeZone( 'UTC' ) );
+		} else {
+			$last_modified = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		}
+
+		gp_update_meta( $this->translation_set->id, static::BUILD_TIME_KEY, $last_modified->format( DATE_ATOM ), 'translation_set' );
 
 		/**
 		 * Fires after a language pack for a given translation set has been generated.
@@ -219,7 +228,7 @@ class ZipProvider {
 	public function get_last_build_time() :? DateTime {
 		$meta = gp_get_meta( 'translation_set', $this->translation_set->id, static::BUILD_TIME_KEY );
 
-		return $meta ? new DateTime( $meta ) : null;
+		return $meta ? new DateTime( $meta, new DateTimeZone( 'UTC' ) ) : null;
 	}
 
 	/**

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -7,6 +7,7 @@
 
 namespace Required\Traduttore\Tests;
 
+use DateTime;
 use \GP_Project;
 use \Required\Traduttore\Project as TraduttoreProject;
 
@@ -151,11 +152,12 @@ class Project extends TestCase {
 	}
 
 	public function test_get_last_updated_time(): void {
-		$time = date( DATE_MYSQL );
+		$time = new DateTime( 'now' );
 
-		$this->project->set_last_updated_time( $time );
+		$this->project->set_last_updated_time( $time->format( DATE_ATOM ) );
 
-		$this->assertSame( $time, $this->project->get_last_updated_time() );
+		$this->assertInstanceOf( DateTime::class, $this->project->get_last_updated_time() );
+		$this->assertEquals( $time, $this->project->get_last_updated_time(), 'Last updated time is not identical', 1 );
 	}
 
 	public function test_get_repository_webhook_secret(): void {

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -154,7 +154,7 @@ class Project extends TestCase {
 	public function test_get_last_updated_time(): void {
 		$time = new DateTime( 'now' );
 
-		$this->project->set_last_updated_time( $time->format( DATE_ATOM ) );
+		$this->project->set_last_updated_time( $time );
 
 		$this->assertInstanceOf( DateTime::class, $this->project->get_last_updated_time() );
 		$this->assertEquals( $time, $this->project->get_last_updated_time(), 'Last updated time is not identical', 1 );

--- a/tests/phpunit/tests/ZipProvider.php
+++ b/tests/phpunit/tests/ZipProvider.php
@@ -7,6 +7,7 @@
 
 namespace Required\Traduttore\Tests;
 
+use DateTime;
 use GP_Translation_Set;
 use Required\Traduttore\ProjectLocator;
 use \Required\Traduttore\ZipProvider as Provider;
@@ -207,9 +208,7 @@ class ZipProvider extends TestCase {
 
 		$provider->generate_zip_file();
 
-		$build_time = $provider->get_last_build_time();
-
-		$this->assertInternalType( 'string', $build_time );
+		$this->assertInstanceOf( DateTime::class, $provider->get_last_build_time() );
 	}
 
 	public function test_remove_zip_file(): void {


### PR DESCRIPTION
**Description**
Fixes #135 by using `DATE_FORMAT` to save the last updated time with timezone information. Also makes sure the getters always return DateTime objects, which makes handling this data easier anyway.

**How has this been tested?**
Updated unit tests accordingly.

**Types of changes**
Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
