### PR TITLE
Only create language packs if project is active

### DIFF
--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -26,6 +26,8 @@ For projects hosted on Bitbucket, the format is slightly different:
 https://bitbucket.org/acme/my-awesome-plugin/src/master/%file%#%file%-%line%
 ```
 
+Mark the project as "Active" for the language packs to be created. The translation strings will continue to be updated with code changes even when the project is set as inactive.
+
 ## Repository Configuration
 
 Depending on where your project is hosted, you need to follow different steps to support automatic translation updates. Please read the according documentation:

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -423,9 +423,12 @@ class ProjectCommand extends WP_CLI_Command {
 
 		$args = array_map(
 			function ( $project ) {
-				$locator = new ProjectLocator( $project );
-
-				return $locator->get_project();
+				$project = ( new ProjectLocator( $project ) )->get_project();
+				if ( $project->is_active() ) {
+					return $project;
+				}
+				WP_CLI::log( sprintf( 'Project (ID: %d) is inactive.', $project->get_id() ) );
+				return null;
 			},
 			$args
 		);

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -56,6 +56,10 @@ class Plugin {
 				/* @var GP_Translation_Set $translation_set */
 				$translation_set = GP::$translation_set->get( $translation->translation_set_id );
 
+				$project = ( new ProjectLocator( $translation_set->project_id ) )->get_project();
+				if ( ! $project || ! $project->is_active() ) {
+					return;
+				}
 				$zip_provider = new ZipProvider( $translation_set );
 
 				$zip_provider->schedule_generation();
@@ -68,6 +72,10 @@ class Plugin {
 				$project = ( new ProjectLocator( $project_id ) )->get_project();
 
 				if ( ! $project ) {
+					return;
+				}
+
+				if ( ! $project->is_active() ) {
 					return;
 				}
 

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -183,6 +183,20 @@ class Project {
 	}
 
 	/**
+	 * Return project if project is active.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool Whether project is active.
+	 */
+	public function is_active(): bool {
+		if ( '1' === $this->project->active ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Returns the project's source URL template.
 	 *
 	 * @since 3.0.0


### PR DESCRIPTION
**Description**
Fixes #138 

**How has this been tested?**
- Ran `docker-compose run cli wp --allow-root --url=translate.required.com.docker.amazee.io traduttore project build prohelvetia/ph-offices-abroad` on a project that I marked as inactive.
- Updated translations and checked that no cron job is scheduled. `docker-compose run cli wp --allow-root --url=translate.required.com.docker.amazee.io cron event list`

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
