### PR TITLE
Update wp-cli documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ Removes the cached source code repository for a given project.
 Useful when the local repository was somehow corrupted.
 
 ```bash
-wp traduttore cache clear <project|repository_url>
+wp traduttore project cache clear <project|repository_url>
 ````
 
 ## Show various details about a project
@@ -50,6 +50,13 @@ This includes things like the text domain and repository URLs.
 wp traduttore project info <project|repository_url>
 ```
 
+## List project language packs
+
+List language packs for the given project.
+
+```bash
+wp traduttore project list <project|repository_url>
+````
 
 ## Show various details about the environment
 

--- a/inc/CLI/CacheCommand.php
+++ b/inc/CLI/CacheCommand.php
@@ -33,15 +33,15 @@ class CacheCommand extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Remove cached repository.
-	 *     $ wp traduttore cache clear https://github.com/wearerequired/required-valencia
+	 *     $ wp traduttore project cache clear https://github.com/wearerequired/required-valencia
 	 *     Success: Removed cached Git repository for project (ID: 123)!
 	 *
 	 *     # Remove cached repository for given project path.
-	 *     $ wp traduttore cache clear required/required-valencia
+	 *     $ wp traduttore project cache clear required/required-valencia
 	 *     Success: Removed cached Git repository for project (ID: 123)!
 	 *
 	 *     # Remove cached repository for given project ID.
-	 *     $ wp traduttore cache clear 123
+	 *     $ wp traduttore project cache clear 123
 	 *     Success: Removed cached Git repository for project (ID: 123)!
 	 *
 	 * @since 2.0.0

--- a/inc/CLI/CommandNamespace.php
+++ b/inc/CLI/CommandNamespace.php
@@ -52,7 +52,7 @@ namespace Required\Traduttore\CLI;
  *     Success: Language pack generation finished
  *
  *     # Remove cached repository for given project ID.
- *     $ wp traduttore cache clear 123
+ *     $ wp traduttore project cache clear 123
  *     Success: Removed cached Git repository for project (ID: 123)!
  */
 class CommandNamespace extends \WP_CLI\Dispatcher\CommandNamespace {


### PR DESCRIPTION
- Cache is now a subcommand of project
- Document `wp traduttore project list`
