### PR TITLE
Fix issue with empty language pack ZIP

### DIFF
--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -149,7 +149,7 @@ class ZipProvider {
 
 		$temp_zip_file = wp_tempnam( $this->get_zip_filename() );
 
-		if ( $zip->open( $temp_zip_file, ZipArchive::OVERWRITE ) === true ) {
+		if ( $zip->open( $temp_zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE ) === true ) {
 			foreach ( $files_for_zip as $file_name => $temp_file ) {
 				$zip->addFile( $temp_file, $file_name );
 			}

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -149,7 +149,7 @@ class ZipProvider {
 
 		$temp_zip_file = wp_tempnam( $this->get_zip_filename() );
 
-		if ( $zip->open( $temp_zip_file, ZipArchive::CREATE ) === true ) {
+		if ( $zip->open( $temp_zip_file, ZipArchive::OVERWRITE ) === true ) {
 			foreach ( $files_for_zip as $file_name => $temp_file ) {
 				$zip->addFile( $temp_file, $file_name );
 			}


### PR DESCRIPTION
**Description**

I changed the second parameter of `ZipArchive->open()` to `OVERWRITE` in order to fix #168.

**How has this been tested?**
With the `wp traduttore language-pack build` command. It generates an empty ZIP with `CREATE` and a correct ZIP with `OVERWRITE`.

**Types of changes**
Bug fix

**Checklist:**
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
