### PR TITLE
Add filter to customize mapping of sources to translation entries.

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -200,3 +200,20 @@ Useful when language packs should be stored somewhere else.
 **Parameters:**
 
 * `$dir`: Cache directory path.
+
+----
+
+### `traduttore.map_entries_to_source`
+
+**Since:** 3.1.0
+
+Filters the mapping of sources to translation entries.
+
+Useful when the source and dist path of JavaScript sources does not match and not only differ in `.js` and `.min.js`.
+
+**Parameters:**
+
+* `$mapping`: The mapping of sources to translation entries.
+* `$entries`: The translation entries to map.
+* `$project`: The project that is exported.
+

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -175,6 +175,15 @@ class Export {
 			$sources = array_unique( $sources );
 
 			foreach ( $sources as $source ) {
+				/**
+				 * Filters the entry source for a JavaScript translation.
+				 *
+				 * @since 3.1.0
+				 *
+				 * @param string  $source  The JS filename with relative path.
+				 * @param Project $project The project that is exported.
+				 */
+				$source = apply_filters( 'traduttore.js_translation_entry_source', $source, $this->project->get_project() );
 				$mapping[ $source ][] = $entry;
 			}
 		}
@@ -199,16 +208,6 @@ class Export {
 
 		foreach ( $mapping as $file => $entries ) {
 			$contents = $format->print_exported_file( $this->project->get_project(), $this->locale, $this->translation_set, $entries );
-
-			/**
-			 * Filters the JavaScript filename (including the relative path) before the md5 hash for the JSON filename is created from it.
-			 *
-			 * @since 3.1.0
-			 *
-			 * @param string  $file    The JS filename with relative path.
-			 * @param Project $project The project that is exported.
-			 */
-			$file = apply_filters( 'traduttore.js_file_for_hash', $file, $this->project->get_project() );
 
 			$hash      = md5( $file );
 			$file_name = "{$base_file_name}-{$hash}.json";

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -175,21 +175,20 @@ class Export {
 			$sources = array_unique( $sources );
 
 			foreach ( $sources as $source ) {
-				/**
-				 * Filters the entry source for a translation.
-				 *
-				 * @since 3.1.0
-				 *
-				 * @param string  $source  The filename with relative path, or `php` for translations from PHP files.
-				 * @param Project $project The project that is exported.
-				 */
-				$source = apply_filters( 'traduttore.translation_entry_source', $source, $this->project->get_project() );
-
 				$mapping[ $source ][] = $entry;
 			}
 		}
 
-		return $mapping;
+		/**
+		 * Filters the mapping of sources to translation entries.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param array               $mapping The mapping of sources to translation entries.
+		 * @param Translation_Entry[] $entries The translation entries to map.
+		 * @param Project             $project The project that is exported.
+		 */
+		return (array) apply_filters( 'traduttore.map_entries_to_source', $mapping, $entries, $this->project );
 	}
 
 	/**

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -200,6 +200,16 @@ class Export {
 		foreach ( $mapping as $file => $entries ) {
 			$contents = $format->print_exported_file( $this->project->get_project(), $this->locale, $this->translation_set, $entries );
 
+			/**
+			 * Filters the JavaScript filename (including the relative path) before the md5 hash for the JSON filename is created from it.
+			 *
+			 * @since 3.1.0
+			 *
+			 * @param string  $file    The JS filename with relative path.
+			 * @param Project $project The project that is exported.
+			 */
+			$file = apply_filters( 'traduttore.js_file_for_hash', $file, $this->project->get_project() );
+
 			$hash      = md5( $file );
 			$file_name = "{$base_file_name}-{$hash}.json";
 			$temp_file = wp_tempnam( $file_name );

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -176,14 +176,14 @@ class Export {
 
 			foreach ( $sources as $source ) {
 				/**
-				 * Filters the entry source for a JavaScript translation.
+				 * Filters the entry source for a translation.
 				 *
 				 * @since 3.1.0
 				 *
-				 * @param string  $source  The JS filename with relative path.
+				 * @param string  $source  The filename with relative path, or `php` for translations from PHP files.
 				 * @param Project $project The project that is exported.
 				 */
-				$source = apply_filters( 'traduttore.js_translation_entry_source', $source, $this->project->get_project() );
+				$source = apply_filters( 'traduttore.translation_entry_source', $source, $this->project->get_project() );
 
 				$mapping[ $source ][] = $entry;
 			}

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -184,6 +184,7 @@ class Export {
 				 * @param Project $project The project that is exported.
 				 */
 				$source = apply_filters( 'traduttore.js_translation_entry_source', $source, $this->project->get_project() );
+
 				$mapping[ $source ][] = $entry;
 			}
 		}

--- a/tests/phpunit/tests/Export.php
+++ b/tests/phpunit/tests/Export.php
@@ -140,6 +140,93 @@ class Export extends TestCase {
 		);
 	}
 
+	/**
+	 * Modify the source of JS files to build.js to test the traduttore.translation_entry_source filter.
+	 *
+	 * @param string $source The translation source.
+	 *
+	 * @return string The maybe modified source.
+	 */
+	public function filter_translation_entry_source( string $source ): string {
+		$wanted_sources = [
+			'my-super-script.js',
+			'my-other-script.js',
+		];
+
+		if ( in_array( $source, $wanted_sources ) ) {
+			return 'build.js';
+		}
+
+		return $source;
+	}
+
+	public function test_translation_entry_source_filter(): void {
+		$filename_1      = 'my-super-script.js';
+		$filename_2      = 'my-other-script.js';
+		$filename_target = 'build.js';
+
+		/* @var \GP_Original $original_1 */
+		$original_1 = $this->factory->original->create(
+			[
+				'project_id' => $this->translation_set->project_id,
+				'references' => $filename_1,
+			]
+		);
+
+		/* @var \GP_Original $original_2 */
+		$original_2 = $this->factory->original->create(
+			[
+				'project_id' => $this->translation_set->project_id,
+				'references' => $filename_2,
+			]
+		);
+
+		$this->factory->translation->create(
+			[
+				'original_id'        => $original_1->id,
+				'translation_set_id' => $this->translation_set->id,
+				'status'             => 'current',
+			]
+		);
+
+		$this->factory->translation->create(
+			[
+				'original_id'        => $original_2->id,
+				'translation_set_id' => $this->translation_set->id,
+				'status'             => 'current',
+			]
+		);
+
+		$export = new E( $this->translation_set );
+
+		add_filter( 'traduttore.translation_entry_source', [ $this, 'filter_translation_entry_source' ] );
+
+		$actual = $export->export_strings();
+
+		remove_filter( 'traduttore.translation_entry_source', [ $this, 'filter_translation_entry_source' ] );
+
+		$json_filename_1      = 'foo-project-de_DE-' . md5( $filename_1 ) . '.json';
+		$json_filename_2      = 'foo-project-de_DE-' . md5( $filename_2 ) . '.json';
+		$json_filename_target = 'foo-project-de_DE-' . md5( $filename_target ) . '.json';
+
+		$this->assertArrayNotHasKey( $json_filename_1, $actual );
+		$this->assertArrayNotHasKey( $json_filename_2, $actual );
+
+		$json = file_get_contents( $actual[ $json_filename_target ] );
+
+		array_map( 'unlink', $actual );
+
+		$this->assertJson( $json );
+		$this->assertEqualSets(
+			[
+				'foo-project-de_DE.po',
+				'foo-project-de_DE.mo',
+				$json_filename_target,
+			],
+			array_keys( $actual )
+		);
+	}
+
 	public function test_js_entries_are_not_in_po_file(): void {
 		$filename_1 = 'my-super-script';
 		$filename_2 = 'my-super-minified-script';

--- a/tests/phpunit/tests/Export.php
+++ b/tests/phpunit/tests/Export.php
@@ -141,26 +141,21 @@ class Export extends TestCase {
 	}
 
 	/**
-	 * Modify the source of JS files to build.js to test the traduttore.translation_entry_source filter.
+	 * Modify the mapping of sources to translation entries.
 	 *
-	 * @param string $source The translation source.
+	 * @param array $mapping The mapping of sources to translation entries.
 	 *
-	 * @return string The maybe modified source.
+	 * @return array The maybe modified mapping.
 	 */
-	public function filter_translation_entry_source( string $source ): string {
-		$wanted_sources = [
-			'my-super-script.js',
-			'my-other-script.js',
-		];
+	public function filter_map_entries_to_source( array $mapping ): string {
+		$mapping['build.js'] = array_merge( $mapping['my-super-script.js'], $mapping['my-other-script.js'] );
 
-		if ( in_array( $source, $wanted_sources ) ) {
-			return 'build.js';
-		}
+		unset( $mapping['my-super-script.js'], $mapping['my-other-script.js'] );
 
-		return $source;
+		return $mapping;
 	}
 
-	public function test_translation_entry_source_filter(): void {
+	public function test_map_entries_to_source_filter(): void {
 		$filename_1      = 'my-super-script.js';
 		$filename_2      = 'my-other-script.js';
 		$filename_target = 'build.js';
@@ -199,11 +194,11 @@ class Export extends TestCase {
 
 		$export = new E( $this->translation_set );
 
-		add_filter( 'traduttore.translation_entry_source', [ $this, 'filter_translation_entry_source' ] );
+		add_filter( 'traduttore.filter_map_entries_to_source', [ $this, 'filter_map_entries_to_source' ] );
 
 		$actual = $export->export_strings();
 
-		remove_filter( 'traduttore.translation_entry_source', [ $this, 'filter_translation_entry_source' ] );
+		remove_filter( 'traduttore.filter_map_entries_to_source', [ $this, 'filter_map_entries_to_source' ] );
 
 		$json_filename_1      = 'foo-project-de_DE-' . md5( $filename_1 ) . '.json';
 		$json_filename_2      = 'foo-project-de_DE-' . md5( $filename_2 ) . '.json';


### PR DESCRIPTION
**Description**

I have the issue, that JS translations are not loaded correctly, because the path to the JS file in the Git repo that is used for the string extraction does not match the JS that is loaded on the website. For example, I have the `blocks/block-name/index.js` in my Repository, but it is compiled to `assets/js/editor.blocks.js`.

So when the `assets/js/editor.blocks.js` is loaded, WP does not find the translation, because the MD5 hash was generated from `blocks/block-name/index.js`.

**How has this been tested?**

I created the following filter call to check the functionality. I added the project as a second parameter to the filter, for the case when one needs more information to decide if a replacement is needed or not (and with what to replace).

```
add_filter( 'traduttore.js_file_for_hash', function( $file ) {
	if ( $file === 'blocks/block-name/index.js' ) {
		return 'assets/js/editor.blocks.js';
	}

	return $file;
} );
```

**Types of changes**
New feature

**Checklist:**
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer lint lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
