### PR TITLE
Projects: Add int type casting for active state

### DIFF
--- a/inc/Project.php
+++ b/inc/Project.php
@@ -190,7 +190,7 @@ class Project {
 	 * @return bool Whether the project is active.
 	 */
 	public function is_active(): bool {
-		return '1' === $this->project->active;
+		return 1 === (int) $this->project->active;
 	}
 
 	/**

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -175,4 +175,8 @@ class Project extends TestCase {
 
 		$this->assertSame( $version, $this->project->get_version() );
 	}
+	
+	public function test_is_active(): void {
+		$this->assertTrue( $this->project->is_active() );
+	}
 }

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -29,7 +29,8 @@ class Project extends TestCase {
 
 		$this->gp_project = $this->factory->project->create(
 			[
-				'name' => 'Project',
+				'name'   => 'Project',
+				'active' => 1,
 			]
 		);
 

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -175,7 +175,7 @@ class Project extends TestCase {
 
 		$this->assertSame( $version, $this->project->get_version() );
 	}
-	
+
 	public function test_is_active(): void {
 		$this->assertTrue( $this->project->is_active() );
 	}


### PR DESCRIPTION
**Description**
GlotPress 3.0 ensures that integer fields have actually a integer value, see https://github.com/GlotPress/GlotPress-WP/commit/1af0bddf0f741573fa896b5ead97baf6db81e19b.

**How has this been tested?**
`wp traduttore language-pack build test-project`

**Types of changes**
 Bug fix: Compat with GlotPress 3.0

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->