### PR TITLE
Don't trim trailing whitespace in Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,18 @@
-# This file is for unifying the coding style for different editors and IDEs
-# editorconfig.org
-
-# WordPress Coding Standards
-# https://make.wordpress.org/core/handbook/coding-standards/
-
 root = true
 
 [*]
 charset = utf-8
+indent_style = tab
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-indent_style = tab
 
-[{.jshintrc,*.json,*.yml}]
+[{*.json,*.yml}]
 indent_style = space
 indent_size = 2
 
-[{*.txt,wp-config-sample.php}]
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
 end_of_line = crlf


### PR DESCRIPTION
**Description**
Updates .editorconfig to not trim trailing whitespace in Markdown files-