### PR TITLE
Docs: Add missing composer install step for alternative installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,6 +36,6 @@ If you're using [Composer](https://getcomposer.org/) to manage dependencies, you
 composer require wearerequired/traduttore
 ```
 
-Alternatively, you can download a ZIP file containing the plugin on [GitHub](https://github.com/wearerequired/traduttore) and upload it in your WordPress admin screen.
+Alternatively, you can download a ZIP file containing the plugin on [GitHub](https://github.com/wearerequired/traduttore). Extract the ZIP file, run ` composer install --no-progress --prefer-dist --optimize-autoloader`, archive the files again and upload the new ZIP file in your WordPress admin screen.
 
 Afterwards, activating Traduttore is all you need to do. There's no special settings UI or anything for it.


### PR DESCRIPTION
**Description**
Fixes https://github.com/wearerequired/traduttore/issues/177.

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Screenshots**
If applicable, add screenshots to show the visual change.


**Types of changes**
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

**Checklist:**
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
