### PR TITLE
Support `application/x-www-form-urlencoded` as content type for GitHub webhook

### DIFF
--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -63,11 +63,21 @@ class GitHub extends Base {
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
 	 */
 	public function callback() {
-		$params     = $this->request->get_params();
 		$event_name = $this->request->get_header( 'x-github-event' );
 
 		if ( 'ping' === $event_name ) {
 			return new WP_REST_Response( [ 'result' => 'OK' ] );
+		}
+
+		$params       = $this->request->get_params();
+		$content_type = $this->request->get_content_type();
+		// See https://developer.github.com/webhooks/creating/#content-type.
+		if ( ! empty( $content_type ) && 'application/x-www-form-urlencoded' === $content_type['value'] ) {
+			$params = json_decode( $params['payload'], true );
+		}
+
+		if ( ! isset( $params['repository']['default_branch'] ) ) {
+			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
 		}
 
 		// We only care about the default branch but don't want to send an error still.
@@ -79,7 +89,7 @@ class GitHub extends Base {
 		$project = $locator->get_project();
 
 		if ( ! $project ) {
-			return new \WP_Error( '404', 'Could not find project for this repository' );
+			return new \WP_Error( '404', 'Could not find project for this repository', [ 'status' => 404 ] );
 		}
 
 		$project->set_repository_name( $params['repository']['full_name'] );


### PR DESCRIPTION
**Description**
Fixes https://github.com/wearerequired/traduttore/issues/166

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Screenshots**
If applicable, add screenshots to show the visual change.


**Types of changes**
New feature

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
