### PR TITLE
Make ProjectLocator more strict when matching paths with existing data

### DIFF
--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -134,7 +134,7 @@ class ProjectLocator {
 		$meta_key = '_traduttore_repository_url';
 
 		$query = $wpdb->prepare(
-			"SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` LIKE %s LIMIT 1",
+			"SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` = %s LIMIT 1",
 			$meta_key,
 			$project
 		);

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -90,14 +90,11 @@ class ProjectLocator {
 	}
 
 	/**
-	 * Finds a GlotPress project by a partially matching repository name meta data.
-	 *
-	 * Given a path like required-valencia, this would match
-	 * a repository name like wearerequired/required-valencia.
+	 * Finds a GlotPress project by matching repository name meta data.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $project Possible repository path or URL.
+	 * @param string $project Possible repository path.
 	 * @return \GP_Project|null Project on success, null otherwise.
 	 */
 	protected function find_by_repository_name( $project ): ?GP_Project {
@@ -105,8 +102,11 @@ class ProjectLocator {
 
 		$meta_key = '_traduttore_repository_name';
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$query = $wpdb->prepare( "SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` LIKE %s LIMIT 1", $meta_key, '%' . $wpdb->esc_like( $project ) . '%' );
+		$query = $wpdb->prepare(
+			"SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` = %s LIMIT 1",
+			$meta_key,
+			$project
+		);
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->get_row( $query );
@@ -121,13 +121,7 @@ class ProjectLocator {
 	}
 
 	/**
-	 * Finds a GlotPress project by a partially matching repository URL meta data.
-	 *
-	 * Given a path like wearerequired/required-valencia, this would match
-	 * a repository URL like https://github.com/wearerequired/required-valencia.
-	 *
-	 * Since there can be projects with the same repository name but different providers,
-	 * this can lead to false positives when not given enough information.
+	 * Finds a GlotPress project by matching repository URL meta data.
 	 *
 	 * @since 3.0.0
 	 *
@@ -139,8 +133,11 @@ class ProjectLocator {
 
 		$meta_key = '_traduttore_repository_url';
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$query = $wpdb->prepare( "SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` LIKE %s LIMIT 1", $meta_key, '%' . $wpdb->esc_like( $project ) . '%' );
+		$query = $wpdb->prepare(
+			"SELECT object_id FROM `$wpdb->gp_meta` WHERE `object_type` = 'project' AND `meta_key` = %s AND `meta_value` LIKE %s LIMIT 1",
+			$meta_key,
+			$project
+		);
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->get_row( $query );
@@ -168,10 +165,14 @@ class ProjectLocator {
 	protected function find_by_source_url_template( $project ): ?GP_Project {
 		global $wpdb;
 
-		$table = GP::$project->table;
+		// Make we don't match 'foo-bar' with a path 'foo'.
+		$project = trailingslashit( $project );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$query = $wpdb->prepare( "SELECT * FROM $table WHERE source_url_template LIKE %s LIMIT 1", '%' . $wpdb->esc_like( $project ) . '%' );
+		$query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT * FROM `$wpdb->gp_projects` WHERE source_url_template LIKE %s LIMIT 1",
+			$wpdb->esc_like( $project ) . '%'
+		);
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$gp_project = GP::$project->coerce( $wpdb->get_row( $query ) );

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -165,7 +165,7 @@ class ProjectLocator {
 	protected function find_by_source_url_template( $project ): ?GP_Project {
 		global $wpdb;
 
-		// Make we don't match 'foo-bar' with a path 'foo'.
+		// Make sure a URL like '…/required' doesn't match …/required-valencia/blob/…'.
 		$project = trailingslashit( $project );
 
 		$query = $wpdb->prepare(

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -147,7 +147,7 @@ class ProjectLocator extends TestCase {
 
 		$project->set_repository_url( 'https://github.com/wearerequired/traduttore-registry' );
 
-		$locator = new Locator( 'wearerequired/traduttore-registry' );
+		$locator = new Locator( 'https://github.com/wearerequired/traduttore-registry' );
 
 		$this->assertEquals( $project->get_id(), $locator->get_project()->get_id() );
 	}


### PR DESCRIPTION
**Description**
Fixes #187.

Remove the partially matching to avoid false positives. It doesn't seem like there's a real use case for this as we have different meta keys to support searching by URL or path. @swissspidy Am I'm missing something here?

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Types of changes**
Bug fix

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
