### PR TITLE
Remove FS_CHMOD_* from phpstan bootstrap file

### DIFF
--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -4,8 +4,6 @@ namespace {
     define( 'WP_CONTENT_DIR', './' );
     define( 'GP_VERSION', '0.0.0' );
     define( 'WP_CLI_VERSION', '0.0.0' );
-    define( 'FS_CHMOD_FILE', 0644 );
-    define( 'FS_CHMOD_DIR', 0755 );
 }
 
 namespace Required\Traduttore {


### PR DESCRIPTION
[New WP extension](https://github.com/szepeviktor/phpstan-wordpress/commit/f5040549dc5f46d81ea2432de726c2a0a4ad1141) contains these constants
