### PR TITLE
Stop on missing coverage files in CI

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -123,14 +123,15 @@ jobs:
         run: composer run-script behat
 
       - name: Retrieve list of coverage files
-        if: ${{ matrix.coverage == true }}
+        if: ${{ matrix.coverage }}
         run: |
-          FILES=$(ls -d -1 "$GITHUB_WORKSPACE/build/logs/clover-behat/"*.* | xargs echo | sed 's/ /,/g')
-          echo $FILES
+          FILES=$(ls -d -1 "$GITHUB_WORKSPACE/build/logs/clover-behat/"*.* | paste --serial --delimiters=",")
+          test -n "$FILES"
+          echo "Coverage files: $FILES"
           echo "COVERAGE_FILES=$FILES" >> $GITHUB_ENV
 
       - name: Upload code coverage report
-        if: ${{ matrix.coverage == true }}
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v1.5.0
         with:
           files: ${{ env.COVERAGE_FILES }}


### PR DESCRIPTION
**Description**

> Todo: update step so it fails if no coverage file exists.

https://github.com/wearerequired/traduttore/pull/124#pullrequestreview-676034729

- booleans are already booleans :)
- (ancient) `paste` is our secret 🔫 
