### PR TITLE
GitLab: Use the correct visibility_level value for public repos

### DIFF
--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -75,7 +75,7 @@ class GitLab extends Base {
 		$project->set_repository_url( $params['project']['homepage'] );
 		$project->set_repository_ssh_url( $params['project']['ssh_url'] );
 		$project->set_repository_https_url( $params['project']['http_url'] );
-		$project->set_repository_visibility( 0 === $params['project']['visibility_level'] ? 'public' : 'private' );
+		$project->set_repository_visibility( 20 === $params['project']['visibility_level'] ? 'public' : 'private' );
 
 		if ( ! $project->get_repository_type() ) {
 			$project->set_repository_type( Repository::TYPE_GITLAB );

--- a/tests/phpunit/tests/WebhookHandler/GitLab.php
+++ b/tests/phpunit/tests/WebhookHandler/GitLab.php
@@ -97,7 +97,7 @@ class GitLab extends TestCase {
 					'homepage'            => 'https://gitlab.com/wearerequired/not-traduttore',
 					'http_url'            => 'https://gitlab.com/wearerequired/not-traduttore.git',
 					'ssh_url'             => 'git@gitlab.com/wearerequired/not-traduttore.git',
-					'visibility_level'    => 0,
+					'visibility_level'    => 20,
 				],
 			]
 		);
@@ -119,7 +119,7 @@ class GitLab extends TestCase {
 					'homepage'            => 'https://gitlab.com/wearerequired/traduttore',
 					'http_url'            => 'https://gitlab.com/wearerequired/traduttore.git',
 					'ssh_url'             => 'git@gitlab.com:wearerequired/traduttore.git',
-					'visibility_level'    => 0,
+					'visibility_level'    => 20,
 				],
 			]
 		);
@@ -153,7 +153,7 @@ class GitLab extends TestCase {
 					'homepage'            => 'https://gitlab.com/wearerequired/traduttore',
 					'http_url'            => 'https://gitlab.com/wearerequired/traduttore.git',
 					'ssh_url'             => 'git@gitlab.com:wearerequired/traduttore.git',
-					'visibility_level'    => 0,
+					'visibility_level'    => 20,
 				],
 			]
 		);


### PR DESCRIPTION
**Description**
If a project is public the value is `20`, `0` means private. See https://docs.gitlab.com/ee/development/permissions.html#general-permissions

Closes #217.

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Screenshots**
If applicable, add screenshots to show the visual change.


**Types of changes**
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
