### PR TITLE
Update wearerequired/coding-standards to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "php-stubs/wp-cli-stubs": "^2.4",
     "phpunit/phpunit": "^7.5.20",
     "szepeviktor/phpstan-wordpress": "^1.1",
-    "wearerequired/coding-standards": "^1.5",
+    "wearerequired/coding-standards": "^2.0",
     "wp-cli/extension-command": "^2.0",
     "wp-cli/rewrite-command": "^2.0",
     "wp-cli/wp-cli-tests": "^3.0.11",

--- a/inc/CLI/CacheCommand.php
+++ b/inc/CLI/CacheCommand.php
@@ -47,7 +47,7 @@ class CacheCommand extends WP_CLI_Command {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param array<mixed> $args Command args.
+	 * @param string[] $args Command args.
 	 */
 	public function clear( array $args ): void {
 		$locator = new ProjectLocator( $args[0] );

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -48,8 +48,8 @@ class InfoCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Command args.
-	 * @param array<mixed> $assoc_args Associative args.
+	 * @param string[] $args Command args.
+	 * @param string[] $assoc_args Associative args.
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$plugin_version = \Required\Traduttore\VERSION;

--- a/inc/CLI/LanguagePackCommand.php
+++ b/inc/CLI/LanguagePackCommand.php
@@ -74,8 +74,8 @@ class LanguagePackCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Command args.
-	 * @param array<mixed> $assoc_args Associative args.
+	 * @param string[] $args       Command args.
+	 * @param string[] $assoc_args Associative args.
 	 */
 	public function list( array $args, array $assoc_args ): void {
 		$locator = new ProjectLocator( $args[0] );
@@ -156,8 +156,8 @@ class LanguagePackCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Command args.
-	 * @param array<mixed> $assoc_args Associative args.
+	 * @param string[] $args Command args.
+	 * @param string[] $assoc_args Associative args.
 	 */
 	public function build( array $args, array $assoc_args ): void {
 		$all      = get_flag_value( $assoc_args, 'all', false );
@@ -216,9 +216,9 @@ class LanguagePackCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Passed arguments.
-	 * @param bool         $all  All flag.
-	 * @return array<mixed> Same as $args if not all, otherwise all slugs.
+	 * @param string[] $args Passed arguments.
+	 * @param bool     $all  All flag.
+	 * @return \Required\Traduttore\Project[] List of projects.
 	 */
 	protected function check_optional_args_and_all( array $args, bool $all ): array {
 		if ( $all ) {

--- a/inc/CLI/LanguagePackCommand.php
+++ b/inc/CLI/LanguagePackCommand.php
@@ -246,7 +246,7 @@ class LanguagePackCommand extends WP_CLI_Command {
 			$args
 		);
 
-		// Remove inexistant projects.
+		// Remove non-existent projects.
 		$projects = array_filter( $projects );
 
 		return $projects;

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -61,8 +61,8 @@ class ProjectCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Command args.
-	 * @param array<mixed> $assoc_args Associative args.
+	 * @param string[] $args Command args.
+	 * @param string[] $assoc_args Associative args.
 	 */
 	public function info( array $args, array $assoc_args ): void {
 		$locator = new ProjectLocator( $args[0] );
@@ -162,8 +162,8 @@ class ProjectCommand extends WP_CLI_Command {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<mixed> $args Command args.
-	 * @param array<mixed> $assoc_args Associative args.
+	 * @param string[] $args       Command args.
+	 * @param string[] $assoc_args Associative args.
 	 */
 	public function update( array $args, array $assoc_args ): void {
 		$delete  = get_flag_value( $assoc_args, 'delete', false );

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -87,11 +87,7 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-<<<<<<< HEAD
-	 * @return array<string, array<string, string>> Configuration data if found.
-=======
-	 * @return string[] Configuration data if found.
->>>>>>> a100cf3 (Update wearerequired/coding-standards to 2.0)
+	 * @return array<string,array<string,string>> Configuration data if found.
 	 */
 	protected function load_config(): array {
 		$config_file   = trailingslashit( $this->path ) . 'traduttore.json';

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -60,7 +60,7 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array<string, mixed> Repository configuration.
+	 * @return array<string,mixed> Repository configuration.
 	 */
 	public function get_config(): array {
 		return $this->config;
@@ -87,7 +87,11 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
+<<<<<<< HEAD
 	 * @return array<string, array<string, string>> Configuration data if found.
+=======
+	 * @return string[] Configuration data if found.
+>>>>>>> a100cf3 (Update wearerequired/coding-standards to 2.0)
 	 */
 	protected function load_config(): array {
 		$config_file   = trailingslashit( $this->path ) . 'traduttore.json';

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -69,7 +69,7 @@ class Export {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array<string, string> List of files with names as key and temporary file location as value.
+	 * @return array<string,string> List of files with names as key and temporary file location as value.
 	 */
 	public function export_strings(): ?array {
 		$entries = GP::$translation->for_export( $this->project->get_project(), $this->translation_set, [ 'status' => 'current' ] );
@@ -142,7 +142,7 @@ class Export {
 	 * @since 3.0.0
 	 *
 	 * @param \Translation_Entry[] $entries The translation entries to map.
-	 * @return array<string, string> The mapping of sources to translation entries.
+	 * @return array<string,string> The mapping of sources to translation entries.
 	 */
 	protected function map_entries_to_source( array $entries ): array {
 		$mapping = [];
@@ -193,7 +193,7 @@ class Export {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array<string, string> $mapping A mapping of files to translation entries.
+	 * @param array<string,string> $mapping A mapping of files to translation entries.
 	 */
 	protected function build_json_files( array $mapping ): void {
 		/** @var \GP_Format $format */

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -110,7 +110,7 @@ class Project {
 	 *
 	 * @param \GP_Project $project GlotPress project.
 	 */
-	public function __construct( \GP_Project $project ) {
+	public function __construct( GP_Project $project ) {
 		$this->project = $project;
 	}
 


### PR DESCRIPTION
**Description**
Update `wearerequired/coding-standards` to version 2.0.

After changing the array type hint PHPStan was returning the following error:
```
 ------ --------------------------------------------- 
  Line   CLI/LanguagePackCommand.php                  
 ------ --------------------------------------------- 
  173    Negated boolean expression is always false.  
 ------ --------------------------------------------- 
```

To fix this I moved the check if the project really existed to `check_optional_args_and_all()`.

**How has this been tested?**
I tested it by running `wp traduttore language-pack build 9999999` as the project 9999999 does not exist.

**Types of changes**
Improve coding standards and return notice if project does not exist.

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
