### PR TITLE
Add `ext-json` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   ],
   "require": {
     "php": ">=7.1",
+    "ext-json": "*",
     "ext-zip": "*",
     "wearerequired/traduttore-registry": "^2.0"
   },


### PR DESCRIPTION
**Description**
<!-- Please describe what you have changed or added -->

Adds `ext-json` requirement to `composer.json` since `json_encode`/`json_decode` is used in various places.

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Screenshots**
If applicable, add screenshots to show the visual change.


**Types of changes**
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Breaking change (requirement change)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
