### PR TITLE
Add a CLI command to unlock a project

### DIFF
--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -230,10 +230,9 @@ class ProjectCommand extends WP_CLI_Command {
 	 *     $ wp traduttore project unlock 123
 	 *     Success: Project unlocked (ID: 123)!
 	 *
-	 * @param string[] $args       Command args.
-	 * @param string[] $assoc_args Associative args.
+	 * @param string[] $args Command args.
 	 */
-	public function unlock( array $args, array $assoc_args ): void {
+	public function unlock( array $args ): void {
 
 		$locator = new ProjectLocator( $args[0] );
 		$project = $locator->get_project();

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -206,4 +206,63 @@ class ProjectCommand extends WP_CLI_Command {
 		WP_CLI::warning( sprintf( 'Could not update translations for project (ID: %d)!', $project->get_id() ) );
 	}
 
+	/**
+	 * Unlocks a project.
+	 *
+	 * Finds the project and removes the lock.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <project|url>
+	 * : Project path / ID or source code repository URL, e.g. https://github.com/wearerequired/required-valencia
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Unlock project with repository URL.
+	 *     $ wp traduttore project unlock https://github.com/wearerequired/required-valencia
+	 *     Success: Project unlocked (ID: 123)!
+	 *
+	 *     # Unlock project with project path.
+	 *     $ wp traduttore project unlock wearerequired/required-valencia
+	 *     Success: Project unlocked (ID: 123)!
+	 *
+	 *     # Unlock project with project ID.
+	 *     $ wp traduttore project unlock 123
+	 *     Success: Project unlocked (ID: 123)!
+	 *
+	 * @param string[] $args       Command args.
+	 * @param string[] $assoc_args Associative args.
+	 */
+	public function unlock( array $args, array $assoc_args ): void {
+
+		$locator = new ProjectLocator( $args[0] );
+		$project = $locator->get_project();
+
+		if ( ! $project ) {
+			WP_CLI::error( 'Project not found' );
+		}
+
+		$repository = ( new RepositoryFactory() )->get_repository( $project );
+
+		if ( ! $repository ) {
+			WP_CLI::error( 'Invalid project type' );
+		}
+
+		$loader = ( new LoaderFactory() )->get_loader( $repository );
+
+		if ( ! $loader ) {
+			WP_CLI::error( 'Invalid project type' );
+		}
+
+		$updater = new Updater( $project );
+
+		if ( ! $updater->has_lock() ) {
+			WP_CLI::error( sprintf( 'Project was not locked (ID: %d)!', $project->get_id() ) );
+		}
+
+		$updater->remove_lock();
+
+		WP_CLI::success( sprintf( 'Project unlocked (ID: %d)!', $project->get_id() ) );
+	}
+
 }


### PR DESCRIPTION
**Description**
In certain situations, a project can get locked. If this happens, there is currently no way to unlock it, except for removing the lock in the database directly.

**How has this been tested?**
In a custom plugin, this command has been registered as a new command in a different namespace, and it could be tested successfully as expected.

**Types of changes**
New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
