### PR TITLE
Add filter to the entries Export status

### DIFF
--- a/inc/Export.php
+++ b/inc/Export.php
@@ -72,7 +72,19 @@ class Export {
 	 * @return array<string,string> List of files with names as key and temporary file location as value.
 	 */
 	public function export_strings(): ?array {
-		$entries = GP::$translation->for_export( $this->project->get_project(), $this->translation_set, [ 'status' => 'current' ] );
+
+		/**
+		 * Filters the status of the entries to export.
+		 *
+		 * @since 3.2.1
+		 *
+		 * @param string                       $export_status   The status of the entries to export. Default is 'current'.
+		 * @param \GP_Translation_Set          $translation_set Translation set the language pack is for.
+		 * @param \Required\Traduttore\Project $project         The project that was updated.
+		 */
+		$export_status = apply_filters( 'traduttore.export_status', 'current', $this->translation_set, $this->project );
+
+		$entries = GP::$translation->for_export( $this->project->get_project(), $this->translation_set, [ 'status' => $export_status ] );
 
 		if ( ! $entries ) {
 			return null;

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -76,7 +76,7 @@ class Export {
 		/**
 		 * Filters the status of the entries to export.
 		 *
-		 * @since 3.2.1
+		 * @since 4.0.0
 		 *
 		 * @param string                       $export_status   The status of the entries to export. Default is 'current'.
 		 * @param \GP_Translation_Set          $translation_set Translation set the language pack is for.


### PR DESCRIPTION
**Description**

This allows to set a custom set of statuses, like 'current_or_untranslated'.

Fix #259 

**How has this been tested?**
1. Set a different value on the status filter.
2. Check out the language packs as desired.

**Types of changes**
New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
