### PR TITLE
Make Traduttore work again with php-cli 2.10.0

### DIFF
--- a/inc/Export.php
+++ b/inc/Export.php
@@ -81,9 +81,9 @@ class Export {
 		// Build a mapping based on where the translation entries occur and separate the po entries.
 		$mapping = $this->map_entries_to_source( $entries );
 
-		$php_entries = \array_key_exists( 'php', $mapping ) ? $mapping['php'] : [];
+		$php_entries = \array_key_exists( 'po', $mapping ) ? $mapping['po'] : [];
 
-		unset( $mapping['php'] );
+		unset( $mapping['po'] );
 
 		$this->build_json_files( $mapping );
 		$this->build_po_file( $php_entries );
@@ -149,25 +149,28 @@ class Export {
 
 		foreach ( $entries as $entry ) {
 			// Find all unique sources this translation originates from.
-			$sources = array_map(
-				function ( $reference ) {
-					$parts = explode( ':', $reference );
-					$file  = $parts[0];
+			if ( ! empty( $entry->references ) ) {
+				$sources = array_map(
+					function ( $reference ) {
+						$parts = explode( ':', $reference );
+						$file  = $parts[0];
 
-					if ( substr( $file, -7 ) === '.min.js' ) {
-						return substr( $file, 0, -7 ) . '.js';
-					}
+						if ( substr( $file, -7 ) === '.min.js' ) {
+							return substr( $file, 0, -7 ) . '.js';
+						}
 
-					if ( substr( $file, -3 ) === '.js' ) {
-						return $file;
-					}
+						if ( substr( $file, -3 ) === '.js' ) {
+							return $file;
+						}
+						return 'po';
+					},
+					$entry->references
+				);
 
-					return 'php';
-				},
-				$entry->references
-			);
-
-			$sources = array_unique( $sources );
+				$sources = array_unique( $sources );
+			} else {
+				$sources = [ 'po' ];
+			}
 
 			foreach ( $sources as $source ) {
 				$mapping[ $source ][] = $entry;


### PR DESCRIPTION
**Description**
I discovered that Traduttore was not working properly any more since updating WP-CLI to 2.10.0 from 2.9.0. For some projects, all translations would end up in the JSON file and leaving the PO file empty.

I originally just wanted to get the strings for "Template name of the Theme" into the PO file. After the Update to WP-CLI 2.10.0 _and_ with this commit, this also works now.

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Screenshots**
### WP-CLI 2.9.0 (without this commit)
![grafik](https://github.com/wearerequired/traduttore/assets/10128264/ecd157e5-29b1-4379-8cb5-e50a1bcd99db)

### WP-CLI 2.10.0 (without this commit)
![grafik](https://github.com/wearerequired/traduttore/assets/10128264/e71d8469-cb47-43f0-961f-14bd0cea3589)
The PO file is now empty.

### WP-CLI 2.10.0 (with this commit)
![grafik](https://github.com/wearerequired/traduttore/assets/10128264/b0a4678d-b247-4283-8dca-daabcb85e6a4)
![grafik](https://github.com/wearerequired/traduttore/assets/10128264/dde64f1b-ea2b-46fb-833a-13434f3ae216)

**Types of changes**
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

**Checklist:**
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
