### PR TITLE
Cleanup, add PHP file support

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -79,7 +79,7 @@ jobs:
           done
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
 
       - name: Make Composer packages available globally
         run: |
@@ -134,8 +134,9 @@ jobs:
 
       - name: Upload code coverage report
         if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage_files.outputs.COVERAGE_FILES }}
           flags: feature
           fail_ci_if_error: true

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -33,29 +33,36 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ '7.4' ]
-        wordpress: [ 'latest', 'nightly' ]
-        glotpress: [ 'develop' ]
+        wordpress: [ 'latest' ]
+        glotpress: [ 'latest' ]
         experimental: [ false ]
         include:
-        # - php: '8.0'
-        #   os: ubuntu-latest
-        #   experimental: true
           - os: ubuntu-latest
-            php: '7.2'
+            php: '8.0'
             wordpress: 'latest'
             glotpress: 'latest'
             experimental: false
           - os: ubuntu-latest
-            php: '7.3'
+            php: '8.1'
             wordpress: 'latest'
             glotpress: 'latest'
             experimental: false
           - os: ubuntu-latest
-            php: '7.4'
+            php: '8.2'
             wordpress: 'latest'
-            glotpress: 'develop'
+            glotpress: 'latest'
             experimental: false
             coverage: true
+          - os: ubuntu-latest
+            php: '8.2'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
+          - os: ubuntu-latest
+            php: '8.3'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -126,7 +126,7 @@ jobs:
           FILES=$(ls -d -1 "$GITHUB_WORKSPACE/build/logs/clover-behat/"*.* | paste --serial --delimiters=",")
           test -n "$FILES"
           echo "Coverage files: $FILES"
-          echo "::set-output name=COVERAGE_FILES::$FILES"
+          echo "COVERAGE_FILES=$FILES" >> $GITHUB_OUTPUT
 
       - name: Upload code coverage report
         if: ${{ matrix.coverage }}

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -67,9 +67,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: ${{ matrix.coverage && 'pcov' || 'none' }}
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: composer
-          ini-values: pcov.directory=.,pcov.exclude=~(vendor|tests)~
 
       - name: Shutdown default MySQL service
         run: sudo service mysql stop

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -32,21 +32,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '7.4' ]
+        php: [ '8.1' ]
         wordpress: [ 'latest' ]
         glotpress: [ 'latest' ]
         experimental: [ false ]
         include:
-          - os: ubuntu-latest
-            php: '8.0'
-            wordpress: 'latest'
-            glotpress: 'latest'
-            experimental: false
-          - os: ubuntu-latest
-            php: '8.1'
-            wordpress: 'latest'
-            glotpress: 'latest'
-            experimental: false
           - os: ubuntu-latest
             php: '8.2'
             wordpress: 'latest'
@@ -60,6 +50,11 @@ jobs:
             experimental: true
           - os: ubuntu-latest
             php: '8.3'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
+          - os: ubuntu-latest
+            php: '8.4'
             wordpress: 'nightly'
             glotpress: 'develop'
             experimental: true

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -53,11 +53,6 @@ jobs:
             wordpress: 'nightly'
             glotpress: 'develop'
             experimental: true
-          - os: ubuntu-latest
-            php: '8.4'
-            wordpress: 'nightly'
-            glotpress: 'develop'
-            experimental: true
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ramsey/composer-install@v3
 
       - name: Lint PHP files
-        run: composer run-script lint -- -q --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs -q --report=checkstyle --severity=1 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
       - name: Analyze PHP files
         run: composer run-script analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -28,7 +28,7 @@ jobs:
           echo "::set-output name=dir::$(composer config home)"
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
 
       - name: Install composer-normalize
         run: composer global require ergebnis/composer-normalize

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: latest
           coverage: none
           tools: composer, cs2pr
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,16 +22,11 @@ jobs:
           coverage: none
           tools: composer, cs2pr
 
-      - name: Get Composer home directory
-        id: composer-home
-        run: |
-          echo "::set-output name=dir::$(composer config home)"
-
       - name: Install PHP dependencies
         uses: ramsey/composer-install@v3
 
       - name: Lint PHP files
-        run: phpcs -q --report=checkstyle | cs2pr
+        run: composer run-script lint -- -q --report=checkstyle | cs2pr
 
       - name: Analyze PHP files
         run: composer run-script analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,14 +30,6 @@ jobs:
       - name: Install PHP dependencies
         uses: ramsey/composer-install@v3
 
-      - name: Install composer-normalize
-        run: composer global require ergebnis/composer-normalize
-
-      - name: Make Composer packages available globally
-        run: |
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
-          echo "${{ steps.composer-home.outputs.dir }}/vendor/bin" >> $GITHUB_PATH
-
       - name: Lint PHP files
         run: phpcs -q --report=checkstyle | cs2pr
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,33 +29,40 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ '7.4' ]
-        wordpress: [ 'latest', 'nightly' ]
-        glotpress: [ 'develop' ]
+        wordpress: [ 'latest' ]
+        glotpress: [ 'latest' ]
         experimental: [ false ]
         include:
-        # - php: '8.0'
-        #   os: ubuntu-latest
-        #   experimental: true
           - os: ubuntu-latest
-            php: '7.2'
+            php: '8.0'
             wordpress: 'latest'
             glotpress: 'latest'
             experimental: false
           - os: ubuntu-latest
-            php: '7.3'
+            php: '8.1'
             wordpress: 'latest'
             glotpress: 'latest'
             experimental: false
           - os: ubuntu-latest
-            php: '7.4'
+            php: '8.2'
             wordpress: 'latest'
-            glotpress: 'develop'
+            glotpress: 'latest'
             experimental: false
             coverage: true
+          - os: ubuntu-latest
+            php: '8.2'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
+          - os: ubuntu-latest
+            php: '8.3'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -65,7 +72,7 @@ jobs:
           tools: composer
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
 
       - name: Make Composer packages available globally
         run: |
@@ -99,7 +106,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage-clover-${{ github.sha }}.xml
           flags: php

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,21 +28,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '7.4' ]
+        php: [ '8.1' ]
         wordpress: [ 'latest' ]
         glotpress: [ 'latest' ]
         experimental: [ false ]
         include:
-          - os: ubuntu-latest
-            php: '8.0'
-            wordpress: 'latest'
-            glotpress: 'latest'
-            experimental: false
-          - os: ubuntu-latest
-            php: '8.1'
-            wordpress: 'latest'
-            glotpress: 'latest'
-            experimental: false
           - os: ubuntu-latest
             php: '8.2'
             wordpress: 'latest'
@@ -56,6 +46,11 @@ jobs:
             experimental: true
           - os: ubuntu-latest
             php: '8.3'
+            wordpress: 'nightly'
+            glotpress: 'develop'
+            experimental: true
+          - os: ubuntu-latest
+            php: '8.4'
             wordpress: 'nightly'
             glotpress: 'develop'
             experimental: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,11 +49,6 @@ jobs:
             wordpress: 'nightly'
             glotpress: 'develop'
             experimental: true
-          - os: ubuntu-latest
-            php: '8.4'
-            wordpress: 'nightly'
-            glotpress: 'develop'
-            experimental: true
 
     steps:
       - name: Check out Git repository

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # PHPUnit
 /coverage*.xml
+.phpunit.result.cache
 
 # Behat
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-* Require at least PHP 7.2. [#236]
+* Require GlotPress 4.0. [#270]
+* Require at least PHP 7.4. [#270]
 
 ### Fixed
 * Pass correct parameter for translation set in `traduttore.generate_zip_delay` filter. [#236]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Require GlotPress 4.0. [#270]
-* Require at least PHP 7.4. [#270]
+* Require at least PHP 8.1. [#270]
 
 ### Fixed
 * Pass correct parameter for translation set in `traduttore.generate_zip_delay` filter. [#236]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Require GlotPress 4.0. [#270]
 * Require at least PHP 8.1. [#270]
+* Added PHP translation file support. [#270]
 
 ### Fixed
 * Pass correct parameter for translation set in `traduttore.generate_zip_delay` filter. [#236]

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -16,7 +16,9 @@ SKIP_DB_CREATE=${7-false}
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_TESTS_FILE="$WP_TESTS_DIR"/includes/functions.php
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+WP_CORE_FILE="$WP_CORE_DIR"/wp-includs.php
 GP_TESTS_DIR="$WP_CORE_DIR/build/wp-content/plugins/glotpress/tests/phpunit"
 
 download() {
@@ -56,10 +58,11 @@ set -ex
 
 install_wp() {
 
-	if [ -d $WP_CORE_DIR ]; then
+	if [ -f $WP_CORE_FILE ]; then
 		return;
 	fi
 
+  rm -rf $WP_CORE_DIR
 	mkdir -p $WP_CORE_DIR
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
@@ -104,9 +107,10 @@ install_test_suite() {
 		local ioption='-i'
 	fi
 
-	# set up testing suite if it doesn't yet exist
-	if [ ! -d $WP_TESTS_DIR ]; then
+	# set up testing suite if it doesn't yet exist or only partially exists
+	if [ ! -f $WP_TESTS_FILE ]; then
 		# set up testing suite
+		rm -rf $WP_TESTS_DIR
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data

--- a/composer.json
+++ b/composer.json
@@ -41,16 +41,18 @@
     "wearerequired/traduttore-registry": "^2.0"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
-    "php-stubs/wp-cli-stubs": "^v2.10",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+    "php-stubs/wordpress-tests-stubs": "^6.5",
+    "php-stubs/wp-cli-stubs": "^2.10",
     "phpstan/extension-installer": "^1.3",
     "phpstan/phpstan-deprecation-rules": "^1.2",
+    "phpstan/phpstan-phpunit": "^1.4",
     "swissspidy/phpstan-no-private": "^0.2.0",
     "szepeviktor/phpstan-wordpress": "^1.3",
     "wearerequired/coding-standards": "^6.0",
     "wp-cli/extension-command": "^2.0",
     "wp-cli/rewrite-command": "^2.0",
-    "wp-cli/wp-cli-tests": "^v4.2.9",
+    "wp-cli/wp-cli-tests": "^4.2.9",
     "wpackagist-plugin/glotpress": "^4.0.0",
     "yoast/phpunit-polyfills": "^1.1"
   },
@@ -75,8 +77,8 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true,
       "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
       "phpstan/extension-installer": true
     },
     "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "issues": "https://github.com/wearerequired/traduttore/issues"
   },
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.1",
     "ext-json": "*",
     "ext-zip": "*",
     "wearerequired/traduttore-registry": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
     "php-stubs/wp-cli-stubs": "^v2.10",
+    "phpstan/extension-installer": "^1.3",
+    "phpstan/phpstan-deprecation-rules": "^1.2",
+    "swissspidy/phpstan-no-private": "^0.2.0",
     "szepeviktor/phpstan-wordpress": "^1.3",
     "wearerequired/coding-standards": "^6.0",
     "wp-cli/extension-command": "^2.0",
@@ -73,7 +76,8 @@
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "composer/installers": true
+      "composer/installers": true,
+      "phpstan/extension-installer": true
     },
     "process-timeout": 7200,
     "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -35,22 +35,21 @@
     "issues": "https://github.com/wearerequired/traduttore/issues"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-json": "*",
     "ext-zip": "*",
     "wearerequired/traduttore-registry": "^2.0"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-    "php-stubs/wp-cli-stubs": "^2.4",
-    "phpunit/phpunit": "^7.5.20",
-    "szepeviktor/phpstan-wordpress": "^1.1",
-    "wearerequired/coding-standards": "^3.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
+    "php-stubs/wp-cli-stubs": "^v2.10",
+    "szepeviktor/phpstan-wordpress": "^1.3",
+    "wearerequired/coding-standards": "^6.0",
     "wp-cli/extension-command": "^2.0",
     "wp-cli/rewrite-command": "^2.0",
-    "wp-cli/wp-cli-tests": "^3.0.11",
-    "wpackagist-plugin/glotpress": "^3.0.0",
-    "yoast/phpunit-polyfills": "^1.0"
+    "wp-cli/wp-cli-tests": "^v4.2.9",
+    "wpackagist-plugin/glotpress": "^4.0.0",
+    "yoast/phpunit-polyfills": "^1.1"
   },
   "suggest": {
     "wpackagist-plugin/slack": "Send Slack notifications for various events"

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+    "ergebnis/composer-normalize": "^2.42",
     "php-stubs/wordpress-tests-stubs": "^6.5",
     "php-stubs/wp-cli-stubs": "^2.10",
     "phpstan/extension-installer": "^1.3",
@@ -79,6 +80,7 @@
     "allow-plugins": {
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
+      "ergebnis/composer-normalize": true,
       "phpstan/extension-installer": true
     },
     "process-timeout": 7200,

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -76,7 +76,7 @@ class InfoCommand extends WP_CLI_Command {
 				'cache_dir'          => $cache_dir,
 			];
 
-			WP_CLI::line( json_encode( $info ) );
+			WP_CLI::line( (string) json_encode( $info ) );
 		} else {
 			WP_CLI::line( "Traduttore version:\t" . $plugin_version );
 			WP_CLI::line( "WordPress version:\t" . $wp_version );

--- a/inc/CLI/InfoCommand.php
+++ b/inc/CLI/InfoCommand.php
@@ -149,7 +149,7 @@ class InfoCommand extends WP_CLI_Command {
 	 * @return null|string Binary path on success, null otherwise.
 	 */
 	protected function get_wp_binary_path(): ?string {
-		if ( \defined( 'TRADUTTORE_WP_BIN' ) && TRADUTTORE_WP_BIN ) {
+		if ( \defined( 'TRADUTTORE_WP_BIN' ) && \is_string( TRADUTTORE_WP_BIN ) ) {
 			return TRADUTTORE_WP_BIN;
 		}
 

--- a/inc/CLI/LanguagePackCommand.php
+++ b/inc/CLI/LanguagePackCommand.php
@@ -96,12 +96,14 @@ class LanguagePackCommand extends WP_CLI_Command {
 
 			$zip_provider = new ZipProvider( $set );
 
+			$last_updated = $zip_provider->get_last_build_time();
+
 			$language_packs[] = [
 				'Locale'       => $locale->wp_locale,
 				'English Name' => $locale->english_name,
 				'Native Name'  => $locale->native_name,
 				'Completed'    => sprintf( '%s%%', $set->percent_translated() ),
-				'Updated'      => $zip_provider->get_last_build_time()->format( DATE_ATOM ),
+				'Updated'      => $last_updated ? $last_updated->format( DATE_ATOM ) : 'n/a',
 				'Package'      => file_exists( $zip_provider->get_zip_path() ) ? $zip_provider->get_zip_url() : 'n/a',
 			];
 		}

--- a/inc/CLI/LanguagePackCommand.php
+++ b/inc/CLI/LanguagePackCommand.php
@@ -162,8 +162,8 @@ class LanguagePackCommand extends WP_CLI_Command {
 	 * @param string[] $assoc_args Associative args.
 	 */
 	public function build( array $args, array $assoc_args ): void {
-		$all      = get_flag_value( $assoc_args, 'all', false );
-		$force    = get_flag_value( $assoc_args, 'force', false );
+		$all      = (bool) get_flag_value( $assoc_args, 'all', false );
+		$force    = (bool) get_flag_value( $assoc_args, 'force', false );
 		$projects = $this->check_optional_args_and_all( $args, $all );
 
 		if ( ! $projects ) {

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -205,5 +205,4 @@ class ProjectCommand extends WP_CLI_Command {
 
 		WP_CLI::warning( sprintf( 'Could not update translations for project (ID: %d)!', $project->get_id() ) );
 	}
-
 }

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -166,8 +166,8 @@ class ProjectCommand extends WP_CLI_Command {
 	 * @param string[] $assoc_args Associative args.
 	 */
 	public function update( array $args, array $assoc_args ): void {
-		$delete  = get_flag_value( $assoc_args, 'delete', false );
-		$cached  = get_flag_value( $assoc_args, 'cached', false );
+		$delete  = (bool) get_flag_value( $assoc_args, 'delete', false );
+		$cached  = (bool) get_flag_value( $assoc_args, 'cached', false );
 		$locator = new ProjectLocator( $args[0] );
 		$project = $locator->get_project();
 

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -88,8 +88,8 @@ class ProjectCommand extends WP_CLI_Command {
 		$repository_visibility = $project->get_repository_visibility() ?? '(unknown)';
 		$repository_ssh_url    = $repository ? $repository->get_ssh_url() : '(unknown)';
 		$repository_https_url  = $repository ? $repository->get_https_url() : '(unknown)';
-		$repository_instance   = $repository ? \get_class( $repository ) : '(unknown)';
-		$loader_instance       = $loader ? \get_class( $loader ) : '(unknown)';
+		$repository_instance   = $repository ? $repository::class : '(unknown)';
+		$loader_instance       = $loader ? $loader::class : '(unknown)';
 
 		if ( get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = [

--- a/inc/CLI/ProjectCommand.php
+++ b/inc/CLI/ProjectCommand.php
@@ -110,7 +110,7 @@ class ProjectCommand extends WP_CLI_Command {
 				'loader_instance'       => $loader_instance,
 			];
 
-			WP_CLI::line( json_encode( $info ) );
+			WP_CLI::line( (string) json_encode( $info ) );
 		} else {
 			WP_CLI::line( "Project ID:\t\t" . $project_id );
 			WP_CLI::line( "Project name:\t\t" . $project_name );

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -12,7 +12,7 @@ namespace Required\Traduttore;
  *
  * @since 3.0.0
  *
- * @phpstan-type ProjectConfig array{ mergeWith?: string, textDomain?: string,exclude?: string }
+ * @phpstan-type ProjectConfig array{ mergeWith?: string, textDomain?: string,exclude?: string[] }
  */
 class Configuration {
 	/**
@@ -29,9 +29,9 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array Repository configuration.
-	 *
 	 * @phpstan-var ProjectConfig
+	 *
+	 * @var array Repository configuration.
 	 */
 	protected $config = [];
 
@@ -64,7 +64,9 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array<string,mixed> Repository configuration.
+	 * @phpstan-return ProjectConfig
+	 *
+	 * @return array<string,string|string[]> Repository configuration.
 	 */
 	public function get_config(): array {
 		return $this->config;
@@ -75,8 +77,12 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
+	 * @phpstan-template T of key-of<ProjectConfig>
+	 * @phpstan-param T $key
+	 * @phpstan-return ProjectConfig[T] | null
+	 *
 	 * @param string $key Config key.
-	 * @return mixed|null Config value.
+	 * @return string|string[]|null Config value.
 	 */
 	public function get_config_value( string $key ) {
 		if ( isset( $this->config[ $key ] ) ) {
@@ -91,15 +97,21 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array<string,array<string,string>> Configuration data if found.
-	 *
 	 * @phpstan-return ProjectConfig
+	 *
+	 * @return array<string,string|string[]> Configuration data if found.
 	 */
 	protected function load_config(): array {
 		$config_file   = trailingslashit( $this->path ) . 'traduttore.json';
 		$composer_file = trailingslashit( $this->path ) . 'composer.json';
 
 		if ( file_exists( $config_file ) ) {
+			/**
+			 * Traduttore configuration.
+			 *
+			 * @phpstan-var ProjectConfig $config
+			 * @var array<string, string | string[]> $config
+			 */
 			$config = json_decode( (string) file_get_contents( $config_file ), true );
 
 			if ( $config ) {
@@ -108,6 +120,12 @@ class Configuration {
 		}
 
 		if ( file_exists( $composer_file ) ) {
+			/**
+			 * Composer configuration.
+			 *
+			 * @phpstan-var array{extra?: array{ traduttore?: ProjectConfig } } $config
+			 * @var array{extra?: array{ traduttore?: array<string, string | string[]> } } $config
+			 */
 			$config = json_decode( (string) file_get_contents( $composer_file ), true );
 
 			if ( $config && isset( $config['extra']['traduttore'] ) ) {

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -33,7 +33,7 @@ class Configuration {
 	 *
 	 * @phpstan-var ProjectConfig
 	 */
-	protected $config = [];
+	protected array $config = [];
 
 	/**
 	 * Class constructor.
@@ -84,7 +84,7 @@ class Configuration {
 	 * @phpstan-param T $key
 	 * @phpstan-return ProjectConfig[T] | null
 	 */
-	public function get_config_value( string $key ): string|array|null {
+	public function get_config_value( string $key ): mixed {
 		if ( isset( $this->config[ $key ] ) ) {
 			return $this->config[ $key ];
 		}

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -11,6 +11,8 @@ namespace Required\Traduttore;
  * Configuration class.
  *
  * @since 3.0.0
+ *
+ * @phpstan-type ProjectConfig array{ mergeWith?: string, textDomain?: string,exclude?: string }
  */
 class Configuration {
 	/**
@@ -28,6 +30,8 @@ class Configuration {
 	 * @since 3.0.0
 	 *
 	 * @var array Repository configuration.
+	 *
+	 * @phpstan-var ProjectConfig
 	 */
 	protected $config = [];
 
@@ -88,6 +92,8 @@ class Configuration {
 	 * @since 3.0.0
 	 *
 	 * @return array<string,array<string,string>> Configuration data if found.
+	 *
+	 * @phpstan-return ProjectConfig
 	 */
 	protected function load_config(): array {
 		$config_file   = trailingslashit( $this->path ) . 'traduttore.json';

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -22,16 +22,16 @@ class Configuration {
 	 *
 	 * @var string Repository path.
 	 */
-	protected $path;
+	protected string $path;
 
 	/**
 	 * Repository configuration.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-var ProjectConfig
-	 *
 	 * @var array Repository configuration.
+	 *
+	 * @phpstan-var ProjectConfig
 	 */
 	protected $config = [];
 
@@ -64,9 +64,9 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-return ProjectConfig
-	 *
 	 * @return array<string,string|string[]> Repository configuration.
+	 *
+	 * @phpstan-return ProjectConfig
 	 */
 	public function get_config(): array {
 		return $this->config;
@@ -77,14 +77,14 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
+	 * @param string $key Config key.
+	 * @return string|string[]|null Config value.
+	 *
 	 * @phpstan-template T of key-of<ProjectConfig>
 	 * @phpstan-param T $key
 	 * @phpstan-return ProjectConfig[T] | null
-	 *
-	 * @param string $key Config key.
-	 * @return string|string[]|null Config value.
 	 */
-	public function get_config_value( string $key ) {
+	public function get_config_value( string $key ): string|array|null {
 		if ( isset( $this->config[ $key ] ) ) {
 			return $this->config[ $key ];
 		}
@@ -97,9 +97,9 @@ class Configuration {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-return ProjectConfig
-	 *
 	 * @return array<string,string|string[]> Configuration data if found.
+	 *
+	 * @phpstan-return ProjectConfig
 	 */
 	protected function load_config(): array {
 		$config_file   = trailingslashit( $this->path ) . 'traduttore.json';

--- a/inc/Configuration.php
+++ b/inc/Configuration.php
@@ -100,7 +100,7 @@ class Configuration {
 		$composer_file = trailingslashit( $this->path ) . 'composer.json';
 
 		if ( file_exists( $config_file ) ) {
-			$config = json_decode( file_get_contents( $config_file ), true );
+			$config = json_decode( (string) file_get_contents( $config_file ), true );
 
 			if ( $config ) {
 				return $config;
@@ -108,7 +108,7 @@ class Configuration {
 		}
 
 		if ( file_exists( $composer_file ) ) {
-			$config = json_decode( file_get_contents( $composer_file ), true );
+			$config = json_decode( (string) file_get_contents( $composer_file ), true );
 
 			if ( $config && isset( $config['extra']['traduttore'] ) ) {
 				return $config['extra']['traduttore'];

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -88,6 +88,7 @@ class Export {
 		$this->build_json_files( $mapping );
 		$this->build_po_file( $php_entries );
 		$this->build_mo_file( $php_entries );
+		$this->build_php_file( $php_entries );
 
 		return $this->files;
 	}
@@ -263,6 +264,28 @@ class Export {
 
 		$base_file_name = $this->get_base_file_name();
 		$file_name      = "{$base_file_name}.mo";
+		$temp_file      = wp_tempnam( $file_name );
+
+		$contents = $format->print_exported_file( $this->project->get_project(), $this->locale, $this->translation_set, $entries );
+
+		if ( $this->write_to_file( $temp_file, $contents ) ) {
+			$this->files[ $file_name ] = $temp_file;
+		}
+	}
+
+	/**
+	 * Builds a PHP file for translations.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @param \Translation_Entry[] $entries The translation entries.
+	 */
+	protected function build_php_file( array $entries ): void {
+		/** @var \GP_Format $format */
+		$format = gp_array_get( GP::$formats, 'php' );
+
+		$base_file_name = $this->get_base_file_name();
+		$file_name      = "{$base_file_name}.l10n.php";
 		$temp_file      = wp_tempnam( $file_name );
 
 		$contents = $format->print_exported_file( $this->project->get_project(), $this->locale, $this->translation_set, $entries );

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -10,7 +10,6 @@ namespace Required\Traduttore;
 use GP;
 use GP_Locales;
 use GP_Translation_Set;
-use InvalidArgumentException;
 
 /**
  * Export strings to translation files in PO, MO, and JSON format.
@@ -25,7 +24,7 @@ class Export {
 	 *
 	 * @var \GP_Translation_Set
 	 */
-	protected $translation_set;
+	protected GP_Translation_Set $translation_set;
 
 	/**
 	 * The current locale.
@@ -43,7 +42,7 @@ class Export {
 	 *
 	 * @var \Required\Traduttore\Project
 	 */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * List of generated files.
@@ -52,7 +51,7 @@ class Export {
 	 *
 	 * @var string[]
 	 */
-	protected $files;
+	protected array $files;
 
 	/**
 	 * Export constructor.
@@ -63,11 +62,12 @@ class Export {
 		$this->translation_set = $translation_set;
 		$this->locale          = GP_Locales::by_slug( $translation_set->locale );
 
+		/**
+		 * GlotPress project.
+		 *
+		 * @var \GP_Project $gp_project
+		 */
 		$gp_project = GP::$project->get( $translation_set->project_id );
-
-		if ( ! $gp_project ) {
-			throw new InvalidArgumentException( __( 'Project not found', 'traduttore' ) );
-		}
 
 		$this->project = new Project( $gp_project );
 	}

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -123,6 +123,10 @@ class Export {
 			}
 		}
 
+		if ( ! $wp_filesystem ) {
+			return false;
+		}
+
 		return $wp_filesystem->put_contents( $file, $contents, FS_CHMOD_FILE );
 	}
 

--- a/inc/Export.php
+++ b/inc/Export.php
@@ -10,7 +10,7 @@ namespace Required\Traduttore;
 use GP;
 use GP_Locales;
 use GP_Translation_Set;
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * Export strings to translation files in PO, MO, and JSON format.
@@ -228,7 +228,7 @@ class Export {
 			$contents = $format->print_exported_file( $this->project->get_project(), $this->locale, $this->translation_set, $entries );
 
 			// Add comment with file reference for debugging.
-			$contents_decoded          = json_decode( $contents );
+			$contents_decoded          = (object) json_decode( $contents );
 			$contents_decoded->comment = [ 'reference' => $file ];
 			$contents                  = (string) wp_json_encode( $contents_decoded );
 

--- a/inc/Loader/Base.php
+++ b/inc/Loader/Base.php
@@ -46,7 +46,7 @@ abstract class Base implements Loader {
 			'%1$straduttore-%2$s-%3$s',
 			get_temp_dir(),
 			$this->repository->get_host(),
-			sanitize_title( $this->repository->get_name() )
+			sanitize_title( $this->repository->get_name() ?? '' )
 		);
 	}
 }

--- a/inc/Loader/Base.php
+++ b/inc/Loader/Base.php
@@ -21,7 +21,7 @@ abstract class Base implements Loader {
 	 *
 	 * @var \Required\Traduttore\Repository Repository object.
 	 */
-	protected $repository;
+	protected Repository $repository;
 
 	/**
 	 * Class constructor.

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -30,7 +30,9 @@ class Git extends Base {
 			chdir( $target );
 			exec( escapeshellcmd( 'git reset --hard -q' ), $output, $status );
 			exec( escapeshellcmd( 'git pull -q' ), $output, $status );
-			chdir( $current_dir );
+			if ( $current_dir ) {
+				chdir( $current_dir );
+			}
 
 			return 0 === $status ? $target : null;
 		}

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -89,6 +89,6 @@ class Git extends Base {
 		 * @param string                          $clone_url  The URL to clone a Git repository.
 		 * @param \Required\Traduttore\Repository $repository The current repository.
 		 */
-		return apply_filters( 'traduttore.git_clone_url', $clone_url, $this->repository );
+		return apply_filters( 'traduttore.git_clone_url', (string) $clone_url, $this->repository );
 	}
 }

--- a/inc/Loader/Mercurial.php
+++ b/inc/Loader/Mercurial.php
@@ -89,6 +89,6 @@ class Mercurial extends Base {
 		 * @param string                          $clone_url  The URL to clone a Mercurial repository.
 		 * @param \Required\Traduttore\Repository $repository The current repository.
 		 */
-		return apply_filters( 'traduttore.hg_clone_url', $clone_url, $this->repository );
+		return apply_filters( 'traduttore.hg_clone_url', (string) $clone_url, $this->repository );
 	}
 }

--- a/inc/Loader/Mercurial.php
+++ b/inc/Loader/Mercurial.php
@@ -30,7 +30,9 @@ class Mercurial extends Base {
 			chdir( $target );
 			exec( escapeshellcmd( 'hg update --clean -q' ), $output, $status );
 			exec( escapeshellcmd( 'hg pull -q' ), $output, $status );
-			chdir( $current_dir );
+			if ( $current_dir ) {
+				chdir( $current_dir );
+			}
 
 			return 0 === $status ? $target : null;
 		}

--- a/inc/Loader/Subversion.php
+++ b/inc/Loader/Subversion.php
@@ -113,6 +113,6 @@ class Subversion extends Base {
 		 * @param string                          $checkout_url The URL to check out a Subversion repository.
 		 * @param \Required\Traduttore\Repository $repository   The current repository.
 		 */
-		return apply_filters( 'traduttore.svn_checkout_url', $checkout_url, $this->repository );
+		return apply_filters( 'traduttore.svn_checkout_url', (string) $checkout_url, $this->repository );
 	}
 }

--- a/inc/Loader/Subversion.php
+++ b/inc/Loader/Subversion.php
@@ -69,7 +69,9 @@ class Subversion extends Base {
 		chdir( $target );
 		exec( escapeshellcmd( 'svn revert --recursive .' ), $output, $status );
 		exec( escapeshellcmd( 'svn update .' ), $output, $status );
-		chdir( $current_dir );
+		if ( $current_dir ) {
+			chdir( $current_dir );
+		}
 
 		return 0 === $status ? $target : null;
 	}

--- a/inc/Loader/Subversion.php
+++ b/inc/Loader/Subversion.php
@@ -53,7 +53,6 @@ class Subversion extends Base {
 		);
 
 		return 0 === $status ? $target : null;
-
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -189,7 +189,7 @@ class Plugin {
 					'description' => __( 'When a new translation ZIP file is built', 'traduttore' ),
 					'message'     => function ( $zip_path, $zip_url, GP_Translation_Set $translation_set ) {
 						/** @var \GP_Locale $locale */
-						$locale  = GP_Locales::by_slug( $translation_set->locale );
+						$locale = GP_Locales::by_slug( $translation_set->locale );
 
 						$gp_project = GP::$project->get( $translation_set->project_id );
 
@@ -397,10 +397,10 @@ class Plugin {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-param \WP_REST_Request<array{}> $request
-	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return bool True if permission is granted, false otherwise.
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 */
 	public function incoming_webhook_permission_callback( WP_REST_Request $request ): bool {
 		$result  = false;
@@ -429,12 +429,12 @@ class Plugin {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-param \WP_REST_Request<array{}> $request
-	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 */
-	public function incoming_webhook_callback( WP_REST_Request $request ) {
+	public function incoming_webhook_callback( WP_REST_Request $request ): \WP_Error|\WP_REST_Response {
 		$result  = new \WP_Error( '400', 'Bad request' );
 		$handler = ( new WebhookHandlerFactory() )->get_handler( $request );
 

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -106,7 +106,7 @@ class Plugin {
 
 		add_action(
 			'traduttore.generate_zip',
-			static function( $translation_set_id ): void {
+			static function ( $translation_set_id ): void {
 				/** @var \GP_Translation_Set $translation_set */
 				$translation_set = GP::$translation_set->get( $translation_set_id );
 
@@ -117,7 +117,7 @@ class Plugin {
 
 		add_filter(
 			'gp_update_meta',
-			static function( $meta_tuple ) {
+			static function ( $meta_tuple ) {
 				$allowed_keys = [
 					Project::VERSION_KEY, // '_traduttore_version'.
 					Project::TEXT_DOMAIN_KEY, // '_traduttore_text_domain'.
@@ -183,11 +183,11 @@ class Plugin {
 
 		add_filter(
 			'slack_get_events',
-			static function( $events ) {
+			static function ( $events ) {
 				$events['traduttore.zip_generated'] = [
 					'action'      => 'traduttore.zip_generated',
 					'description' => __( 'When a new translation ZIP file is built', 'traduttore' ),
-					'message'     => function( $zip_path, $zip_url, GP_Translation_Set $translation_set ) {
+					'message'     => function ( $zip_path, $zip_url, GP_Translation_Set $translation_set ) {
 						/** @var \GP_Locale $locale */
 						$locale  = GP_Locales::by_slug( $translation_set->locale );
 						$project = new Project( GP::$project->get( $translation_set->project_id ) );
@@ -231,7 +231,7 @@ class Plugin {
 				$events['traduttore.updated'] = [
 					'action'      => 'traduttore.updated',
 					'description' => __( 'When new translations are updated for a project', 'traduttore' ),
-					'message'     => function( Project $project, array $stats ) {
+					'message'     => function ( Project $project, array $stats ) {
 						[
 							$originals_added,
 							$originals_existing, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -419,7 +419,7 @@ class Plugin {
 		 * @param \Required\Traduttore\WebhookHandler|null $handler The current webhook handler if found.
 		 * @param \WP_REST_Request                         $request The current request.
 		 */
-		return apply_filters( 'traduttore.incoming_webhook_permission_callback', (bool) $result, $handler, $request );
+		return apply_filters( 'traduttore.incoming_webhook_permission_callback', $result, $handler, $request );
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -390,6 +390,8 @@ class Plugin {
 	 *
 	 * @since 3.0.0
 	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
+	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return bool True if permission is granted, false otherwise.
 	 */
@@ -419,6 +421,8 @@ class Plugin {
 	 * Picks a webhook handler based on the request information.
 	 *
 	 * @since 3.0.0
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -419,7 +419,7 @@ class Plugin {
 		 * @param \Required\Traduttore\WebhookHandler|null $handler The current webhook handler if found.
 		 * @param \WP_REST_Request                         $request The current request.
 		 */
-		return apply_filters( 'traduttore.incoming_webhook_permission_callback', $result, $handler, $request );
+		return apply_filters( 'traduttore.incoming_webhook_permission_callback', (bool) $result, $handler, $request );
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -190,7 +190,14 @@ class Plugin {
 					'message'     => function ( $zip_path, $zip_url, GP_Translation_Set $translation_set ) {
 						/** @var \GP_Locale $locale */
 						$locale  = GP_Locales::by_slug( $translation_set->locale );
-						$project = new Project( GP::$project->get( $translation_set->project_id ) );
+
+						$gp_project = GP::$project->get( $translation_set->project_id );
+
+						if ( ! $gp_project ) {
+							return false;
+						}
+
+						$project = new Project( $gp_project );
 
 						/**
 						 * Filters whether a Slack notification for translation updates from GitHub should be sent.

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -101,7 +101,7 @@ class Project {
 	 *
 	 * @var \GP_Project Project information.
 	 */
-	protected $project;
+	protected GP_Project $project;
 
 	/**
 	 * Project constructor.

--- a/inc/Project.php
+++ b/inc/Project.php
@@ -190,6 +190,11 @@ class Project {
 	 * @return string|null Repository type if stored, null otherwise.
 	 */
 	public function get_repository_type(): ?string {
+		/**
+		 * Project type.
+		 *
+		 * @var string|false $type
+		 */
 		$type = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_TYPE_KEY );
 
 		return $type ?: null;
@@ -215,6 +220,11 @@ class Project {
 	 * @return null|string VCS type if stored, null otherwise.
 	 */
 	public function get_repository_vcs_type(): ?string {
+		/**
+		 * VCS type.
+		 *
+		 * @var string|false $type
+		 */
 		$type = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_VCS_TYPE_KEY );
 
 		return $type ?: null;
@@ -240,6 +250,11 @@ class Project {
 	 * @return null|string Repository URL if stored, null otherwise.
 	 */
 	public function get_repository_url(): ?string {
+		/**
+		 * Repository URL.
+		 *
+		 * @var string|false $url
+		 */
 		$url = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_URL_KEY );
 
 		return $url ?: null;
@@ -265,6 +280,11 @@ class Project {
 	 * @return null|string Repository name if stored, null otherwise.
 	 */
 	public function get_repository_name(): ?string {
+		/**
+		 * Repository name.
+		 *
+		 * @var string|false $name
+		 */
 		$name = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_NAME_KEY );
 
 		return $name ?: null;
@@ -290,6 +310,11 @@ class Project {
 	 * @return null|string Repository visibility if stored, null otherwise.
 	 */
 	public function get_repository_visibility(): ?string {
+		/**
+		 * Repository visibility.
+		 *
+		 * @var string|false $visibility
+		 */
 		$visibility = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_VISIBILITY_KEY );
 
 		return $visibility ?: null;
@@ -313,6 +338,11 @@ class Project {
 	 * @return null|string Repository SSH URL if stored, null otherwise.
 	 */
 	public function get_repository_ssh_url(): ?string {
+		/**
+		 * Repository SSH URL.
+		 *
+		 * @var string|false $url
+		 */
 		$url = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_SSH_URL_KEY );
 
 		return $url ?: null;
@@ -338,6 +368,11 @@ class Project {
 	 * @return null|string Repository HTTPS URL if stored, null otherwise.
 	 */
 	public function get_repository_https_url(): ?string {
+		/**
+		 * Repository HTTPS URL.
+		 *
+		 * @var string|false $url
+		 */
 		$url = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_HTTPS_URL_KEY );
 
 		return $url ?: null;
@@ -363,6 +398,11 @@ class Project {
 	 * @return null|string Webhook sync secret if stored, null otherwise.
 	 */
 	public function get_repository_webhook_secret(): ?string {
+		/**
+		 * Repository webhook secret.
+		 *
+		 * @var string|false $name
+		 */
 		$name = gp_get_meta( 'project', $this->project->id, static::REPOSITORY_WEBHOOK_SECRET_KEY );
 
 		return $name ?: null;
@@ -388,6 +428,11 @@ class Project {
 	 * @return null|string Text domain if stored, null otherwise.
 	 */
 	public function get_text_domain(): ?string {
+		/**
+		 * Project text domain
+		 *
+		 * @var string|false $name
+		 */
 		$name = gp_get_meta( 'project', $this->project->id, static::TEXT_DOMAIN_KEY );
 
 		return $name ?: null;
@@ -413,6 +458,11 @@ class Project {
 	 * @return null|\DateTime Last updated time if stored, null otherwise.
 	 */
 	public function get_last_updated_time(): ?DateTime {
+		/**
+		 * Project last updated time.
+		 *
+		 * @var string|false $time
+		 */
 		$time = gp_get_meta( 'project', $this->project->id, static::UPDATE_TIME_KEY );
 
 		return $time ? new DateTime( $time, new DateTimeZone( 'UTC' ) ) : null;
@@ -438,6 +488,11 @@ class Project {
 	 * @return null|string Version number if stored, null otherwise.
 	 */
 	public function get_version(): ?string {
+		/**
+		 * Project version number.
+		 *
+		 * @var string|false $version
+		 */
 		$version = gp_get_meta( 'project', $this->project->id, static::VERSION_KEY );
 
 		return $version ?: null;

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -23,16 +23,16 @@ class ProjectLocator {
 	 *
 	 * @var \Required\Traduttore\Project|null Project instance.
 	 */
-	protected $project;
+	protected ?Project $project;
 
 	/**
 	 * ProjectLocator constructor.
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int|string|Project|GP_Project $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|false|null|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 */
-	public function __construct( $project ) {
+	public function __construct( int|string|false|\Required\Traduttore\Project|\GP_Project|null $project ) {
 		$this->project = $this->find_project( $project );
 	}
 
@@ -52,10 +52,10 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int|string|Project|GP_Project $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|false|null|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 * @return \Required\Traduttore\Project Project instance.
 	 */
-	protected function find_project( $project ): ?Project {
+	protected function find_project( int|string|false|\Required\Traduttore\Project|\GP_Project|null $project ): ?Project {
 		if ( ! $project ) {
 			return null;
 		}

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -9,7 +9,6 @@ namespace Required\Traduttore;
 
 use GP;
 use GP_Project;
-use http\Exception\InvalidArgumentException;
 
 /**
  * Helper class to find a GlotPress project based on path, ID, or GitHub repository URL.
@@ -22,7 +21,7 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @var \Required\Traduttore\Project Project instance.
+	 * @var \Required\Traduttore\Project|null Project instance.
 	 */
 	protected $project;
 
@@ -31,16 +30,10 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param mixed $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|Project|GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 */
 	public function __construct( $project ) {
-		$found = $this->find_project( $project );
-
-		if ( ! $found ) {
-			throw new InvalidArgumentException( __( 'Project not found', 'traduttore' ) );
-		}
-
-		$this->project = $found;
+		$this->project = $this->find_project( $project );
 	}
 
 	/**
@@ -59,7 +52,7 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param mixed $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|Project|GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 * @return \Required\Traduttore\Project Project instance.
 	 */
 	protected function find_project( $project ): ?Project {
@@ -82,15 +75,15 @@ class ProjectLocator {
 		}
 
 		if ( ! $found ) {
-			$found = $this->find_by_repository_name( $project );
+			$found = $this->find_by_repository_name( (string) $project );
 		}
 
 		if ( ! $found ) {
-			$found = $this->find_by_repository_url( $project );
+			$found = $this->find_by_repository_url( (string) $project );
 		}
 
 		if ( ! $found ) {
-			$found = $this->find_by_source_url_template( $project );
+			$found = $this->find_by_source_url_template( (string) $project );
 		}
 
 		return $found ? new Project( $found ) : null;

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -9,6 +9,7 @@ namespace Required\Traduttore;
 
 use GP;
 use GP_Project;
+use http\Exception\InvalidArgumentException;
 
 /**
  * Helper class to find a GlotPress project based on path, ID, or GitHub repository URL.
@@ -33,7 +34,13 @@ class ProjectLocator {
 	 * @param mixed $project Possible GlotPress project ID or path or source code repository path.
 	 */
 	public function __construct( $project ) {
-		$this->project = $this->find_project( $project );
+		$found = $this->find_project( $project );
+
+		if ( ! $found ) {
+			throw new InvalidArgumentException( __( 'Project not found', 'traduttore' ) );
+		}
+
+		$this->project = $found;
 	}
 
 	/**

--- a/inc/ProjectLocator.php
+++ b/inc/ProjectLocator.php
@@ -30,9 +30,9 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int|string|false|null|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 */
-	public function __construct( int|string|false|\Required\Traduttore\Project|\GP_Project|null $project ) {
+	public function __construct( int|string|Project|\GP_Project $project ) {
 		$this->project = $this->find_project( $project );
 	}
 
@@ -52,10 +52,10 @@ class ProjectLocator {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int|string|false|null|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
+	 * @param int|string|\Required\Traduttore\Project|\GP_Project $project Possible GlotPress project ID or path or source code repository path.
 	 * @return \Required\Traduttore\Project Project instance.
 	 */
-	protected function find_project( int|string|false|\Required\Traduttore\Project|\GP_Project|null $project ): ?Project {
+	protected function find_project( int|string|Project|\GP_Project $project ): ?Project {
 		if ( ! $project ) {
 			return null;
 		}

--- a/inc/Repository/Base.php
+++ b/inc/Repository/Base.php
@@ -79,9 +79,10 @@ abstract class Base implements Repository {
 	 * @return string Repository host name.
 	 */
 	public function get_host(): ?string {
-		$url = $this->project->get_repository_url();
+		$url  = $this->project->get_repository_url();
+		$host = $url ? wp_parse_url( $url, PHP_URL_HOST ) : null;
 
-		return $url ? wp_parse_url( $url, PHP_URL_HOST ) : null;
+		return $host ?: null;
 	}
 
 	/**
@@ -105,7 +106,8 @@ abstract class Base implements Repository {
 			}
 
 			if ( $url ) {
-				$path  = trim( wp_parse_url( $url, PHP_URL_PATH ), '/' );
+				$path = wp_parse_url( $url, PHP_URL_PATH );
+				$path  = $path ? trim( $path, '/' ) : '';
 				$parts = explode( '/', $path );
 				$name  = implode( '/', array_splice( $parts, 0, 2 ) );
 			}

--- a/inc/Repository/Base.php
+++ b/inc/Repository/Base.php
@@ -23,7 +23,7 @@ abstract class Base implements Repository {
 	 *
 	 * @var \Required\Traduttore\Project Project information.
 	 */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * Loader constructor.
@@ -106,7 +106,7 @@ abstract class Base implements Repository {
 			}
 
 			if ( $url ) {
-				$path = wp_parse_url( $url, PHP_URL_PATH );
+				$path  = wp_parse_url( $url, PHP_URL_PATH );
 				$path  = $path ? trim( $path, '/' ) : '';
 				$parts = explode( '/', $path );
 				$name  = implode( '/', array_splice( $parts, 0, 2 ) );

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -65,6 +65,10 @@ class Runner {
 			}
 		}
 
+		if ( ! $wp_filesystem ) {
+			return false;
+		}
+
 		return $wp_filesystem->rmdir( $this->loader->get_local_path(), true );
 	}
 

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -22,7 +22,7 @@ class Runner {
 	 *
 	 * @var \Required\Traduttore\Loader VCS loader.
 	 */
-	protected $loader;
+	protected Loader $loader;
 
 	/**
 	 * Updater instance.
@@ -31,7 +31,7 @@ class Runner {
 	 *
 	 * @var \Required\Traduttore\Updater Translation updater.
 	 */
-	protected $updater;
+	protected Updater $updater;
 
 	/**
 	 * Runner constructor.

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -128,7 +128,7 @@ class Updater {
 		$this->project->set_text_domain( sanitize_text_field( $translations->headers['X-Domain'] ) );
 
 		if ( $translations->headers['Project-Id-Version'] ) {
-			$this->project->set_version( $this->extract_version( $translations->headers['Project-Id-Version'] ) );
+			$this->project->set_version( $this->extract_version( $translations->headers['Project-Id-Version'] ) ?? '' );
 		}
 
 		$stats = GP::$original->import_for_project( $this->project->get_project(), $translations );

--- a/inc/Updater.php
+++ b/inc/Updater.php
@@ -32,7 +32,7 @@ class Updater {
 	 *
 	 * @var \Required\Traduttore\Project Project information.
 	 */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * Returns a new loader instance for a given project.
@@ -221,7 +221,7 @@ class Updater {
 	 * @return string WP-CLI binary path.
 	 */
 	protected function get_wp_bin(): string {
-		if ( \defined( 'TRADUTTORE_WP_BIN' ) && TRADUTTORE_WP_BIN ) {
+		if ( \defined( 'TRADUTTORE_WP_BIN' ) && \is_string( TRADUTTORE_WP_BIN ) ) {
 			return TRADUTTORE_WP_BIN;
 		}
 

--- a/inc/WebhookHandler.php
+++ b/inc/WebhookHandler.php
@@ -20,9 +20,9 @@ interface WebhookHandler {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-param \WP_REST_Request<array{}> $request
-	 *
 	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 */
 	public function __construct( WP_REST_Request $request );
 
@@ -42,5 +42,5 @@ interface WebhookHandler {
 	 *
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
 	 */
-	public function callback();
+	public function callback(): \WP_Error|\WP_REST_Response;
 }

--- a/inc/WebhookHandler.php
+++ b/inc/WebhookHandler.php
@@ -20,6 +20,8 @@ interface WebhookHandler {
 	 *
 	 * @since 3.0.0
 	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
+	 *
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	public function __construct( WP_REST_Request $request );

--- a/inc/WebhookHandler.php
+++ b/inc/WebhookHandler.php
@@ -33,7 +33,7 @@ interface WebhookHandler {
 	 *
 	 * @return bool True if permission is granted, false otherwise.
 	 */
-	public function permission_callback(): ?bool;
+	public function permission_callback(): bool;
 
 	/**
 	 * Callback for incoming webhooks.

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -23,6 +23,8 @@ abstract class Base implements WebhookHandler {
 	 * @since 3.0.0
 	 *
 	 * @var \WP_REST_Request The current REST request.
+	 *
+	 * @phpstan-var \WP_REST_Request<array{}>
 	 */
 	protected $request;
 
@@ -30,6 +32,8 @@ abstract class Base implements WebhookHandler {
 	 * Class constructor.
 	 *
 	 * @since 3.0.0
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 */

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -26,16 +26,16 @@ abstract class Base implements WebhookHandler {
 	 *
 	 * @phpstan-var \WP_REST_Request<array{}>
 	 */
-	protected $request;
+	protected WP_REST_Request $request;
 
 	/**
 	 * Class constructor.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-param \WP_REST_Request<array{}> $request
-	 *
 	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 */
 	public function __construct( WP_REST_Request $request ) {
 		$this->request = $request;
@@ -79,7 +79,7 @@ abstract class Base implements WebhookHandler {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string                              $secret  Webhook sync secret.
+		 * @param string|null                         $secret  Webhook sync secret.
 		 * @param \Required\Traduttore\WebhookHandler $handler The current webhook handler instance.
 		 * @param \Required\Traduttore\Project|null   $project The current project if passed through.
 		 */

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -45,7 +45,7 @@ class Bitbucket extends Base {
 				return false;
 			}
 
-			$payload_signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $params ), $secret );
+			$payload_signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $params ), $secret );
 
 			return hash_equals( $token, $payload_signature );
 		}

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -34,7 +34,7 @@ class Bitbucket extends Base {
 			return false;
 		}
 
-		$token   = $this->request->get_header( 'x-hub-signature' );
+		$token   = $this->request->get_header( 'x-hub-signature-256' );
 		$params  = $this->request->get_params();
 		$locator = new ProjectLocator( $params['repository']['links']['html']['href'] ?? null );
 		$project = $locator->get_project();
@@ -60,7 +60,7 @@ class Bitbucket extends Base {
 	 *
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
 	 */
-	public function callback() {
+	public function callback(): \WP_Error|\WP_REST_Response {
 		$params = $this->request->get_params();
 
 		$locator = new ProjectLocator( $params['repository']['links']['html']['href'] );

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -45,7 +45,7 @@ class Bitbucket extends Base {
 				return false;
 			}
 
-			$payload_signature = 'sha256=' . hash_hmac( 'sha256', $this->request->get_body(), $secret );
+			$payload_signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $params ), $secret );
 
 			return hash_equals( $token, $payload_signature );
 		}

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -34,9 +34,15 @@ class Bitbucket extends Base {
 			return false;
 		}
 
-		$token   = $this->request->get_header( 'x-hub-signature-256' );
-		$params  = $this->request->get_params();
-		$locator = new ProjectLocator( $params['repository']['links']['html']['href'] ?? null );
+		$token      = $this->request->get_header( 'x-hub-signature-256' );
+		$params     = $this->request->get_params();
+		$repository = $params['repository']['links']['html']['href'] ?? null;
+
+		if ( ! $repository ) {
+			return false;
+		}
+
+		$locator = new ProjectLocator( $repository );
 		$project = $locator->get_project();
 		$secret  = $this->get_secret( $project );
 
@@ -45,7 +51,7 @@ class Bitbucket extends Base {
 				return false;
 			}
 
-			$payload_signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $params ), $secret );
+			$payload_signature = 'sha256=' . hash_hmac( 'sha256', $this->request->get_body(), $secret );
 
 			return hash_equals( $token, $payload_signature );
 		}

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -27,7 +27,7 @@ class Bitbucket extends Base {
 	 *
 	 * @return bool True if permission is granted, false otherwise.
 	 */
-	public function permission_callback(): ?bool {
+	public function permission_callback(): bool {
 		$event_name = $this->request->get_header( 'x-event-key' );
 
 		if ( 'repo:push' !== $event_name ) {

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -50,7 +50,7 @@ class GitHub extends Base {
 
 		$secret = $this->get_secret( $project );
 
-		$payload_signature = 'sha1=' . hash_hmac( 'sha1', $this->request->get_body(), $secret );
+		$payload_signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $params ), $secret );
 
 		return hash_equals( $token, $payload_signature );
 	}

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -50,7 +50,7 @@ class GitHub extends Base {
 
 		$secret = $this->get_secret( $project );
 
-		$payload_signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $params ), $secret );
+		$payload_signature = 'sha1=' . hash_hmac( 'sha1', (string) wp_json_encode( $params ), $secret );
 
 		return hash_equals( $token, $payload_signature );
 	}

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -27,7 +27,7 @@ class GitHub extends Base {
 	 *
 	 * @return bool True if permission is granted, false otherwise.
 	 */
-	public function permission_callback(): ?bool {
+	public function permission_callback(): bool {
 		$event_name = $this->request->get_header( 'x-github-event' );
 
 		if ( 'ping' === $event_name ) {

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -50,6 +50,10 @@ class GitHub extends Base {
 
 		$secret = $this->get_secret( $project );
 
+		if ( ! $secret ) {
+			return false;
+		}
+
 		$payload_signature = 'sha1=' . hash_hmac( 'sha1', (string) wp_json_encode( $params ), $secret );
 
 		return hash_equals( $token, $payload_signature );

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -38,7 +38,7 @@ class GitHub extends Base {
 			return false;
 		}
 
-		$token = $this->request->get_header( 'x-hub-signature' );
+		$token = $this->request->get_header( 'x-hub-signature-256' );
 
 		if ( ! $token ) {
 			return false;
@@ -54,7 +54,7 @@ class GitHub extends Base {
 			return false;
 		}
 
-		$payload_signature = 'sha1=' . hash_hmac( 'sha1', $this->request->get_body(), $secret );
+		$payload_signature = 'sha256=' . hash_hmac( 'sha256', $this->request->get_body(), $secret );
 
 		return hash_equals( $token, $payload_signature );
 	}
@@ -66,7 +66,7 @@ class GitHub extends Base {
 	 *
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
 	 */
-	public function callback() {
+	public function callback(): \WP_Error|\WP_REST_Response {
 		$event_name = $this->request->get_header( 'x-github-event' );
 
 		if ( 'ping' === $event_name ) {

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -54,7 +54,7 @@ class GitHub extends Base {
 			return false;
 		}
 
-		$payload_signature = 'sha1=' . hash_hmac( 'sha1', (string) wp_json_encode( $params ), $secret );
+		$payload_signature = 'sha1=' . hash_hmac( 'sha1', $this->request->get_body(), $secret );
 
 		return hash_equals( $token, $payload_signature );
 	}
@@ -75,10 +75,17 @@ class GitHub extends Base {
 
 		$params       = $this->request->get_params();
 		$content_type = $this->request->get_content_type();
+
 		// See https://developer.github.com/webhooks/creating/#content-type.
 		if ( ! empty( $content_type ) && 'application/x-www-form-urlencoded' === $content_type['value'] ) {
 			$params = json_decode( $params['payload'], true );
 		}
+
+		/**
+		 * Request params.
+		 *
+		 * @var array{repository: array{ default_branch?: string, html_url: string, full_name: string, ssh_url: string, clone_url: string, private: bool }, ref: string } $params
+		 */
 
 		if ( ! isset( $params['repository']['default_branch'] ) ) {
 			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -27,7 +27,7 @@ class GitLab extends Base {
 	 *
 	 * @return bool True if permission is granted, false otherwise.
 	 */
-	public function permission_callback(): ?bool {
+	public function permission_callback(): bool {
 		$event_name = $this->request->get_header( 'x-gitlab-event' );
 
 		if ( 'Push Hook' !== $event_name ) {

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -46,6 +46,10 @@ class GitLab extends Base {
 
 		$secret = $this->get_secret( $project );
 
+		if ( ! $secret ) {
+			return false;
+		}
+
 		return hash_equals( $token, $secret );
 	}
 

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -60,7 +60,7 @@ class GitLab extends Base {
 	 *
 	 * @return \WP_Error|\WP_REST_Response REST response on success, error object on failure.
 	 */
-	public function callback() {
+	public function callback(): \WP_Error|\WP_REST_Response {
 		$params = $this->request->get_params();
 
 		// We only care about the default branch but don't want to send an error still.

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -40,8 +40,14 @@ class GitLab extends Base {
 			return false;
 		}
 
-		$params  = $this->request->get_params();
-		$locator = new ProjectLocator( $params['project']['homepage'] ?? null );
+		$params     = $this->request->get_params();
+		$repository = $params['project']['homepage'] ?? null;
+
+		if ( ! $repository ) {
+			return false;
+		}
+
+		$locator = new ProjectLocator( $repository );
 		$project = $locator->get_project();
 
 		$secret = $this->get_secret( $project );

--- a/inc/WebhookHandlerFactory.php
+++ b/inc/WebhookHandlerFactory.php
@@ -23,6 +23,8 @@ class WebhookHandlerFactory {
 	 *
 	 * @since 3.0.0
 	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
+	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \Required\Traduttore\WebhookHandler Webhook handler instance.
 	 */

--- a/inc/WebhookHandlerFactory.php
+++ b/inc/WebhookHandlerFactory.php
@@ -23,10 +23,10 @@ class WebhookHandlerFactory {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @phpstan-param \WP_REST_Request<array{}> $request
-	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \Required\Traduttore\WebhookHandler Webhook handler instance.
+	 *
+	 * @phpstan-param \WP_REST_Request<array{}> $request
 	 */
 	public function get_handler( WP_REST_Request $request ): ?WebhookHandler {
 		$handler = null;

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -12,7 +12,7 @@ use DateTimeZone;
 use GP;
 use GP_Locales;
 use GP_Translation_Set;
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use ZipArchive;
 
 /**
@@ -265,6 +265,11 @@ class ZipProvider {
 	 * @return \DateTime Last build time.
 	 */
 	public function get_last_build_time(): ?DateTime {
+		/**
+		 * Build time.
+		 *
+		 * @var string|false $meta
+		 */
 		$meta = gp_get_meta( 'translation_set', $this->translation_set->id, static::BUILD_TIME_KEY );
 
 		return $meta ? new DateTime( $meta, new DateTimeZone( 'UTC' ) ) : null;

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -10,9 +10,9 @@ namespace Required\Traduttore;
 use DateTime;
 use DateTimeZone;
 use GP;
+use GP_Locale;
 use GP_Locales;
 use GP_Translation_Set;
-use InvalidArgumentException;
 use ZipArchive;
 
 /**
@@ -42,7 +42,7 @@ class ZipProvider {
 	 *
 	 * @var \GP_Translation_Set The translation set.
 	 */
-	protected $translation_set;
+	protected GP_Translation_Set $translation_set;
 
 	/**
 	 * The current GlotPress locale.
@@ -51,7 +51,7 @@ class ZipProvider {
 	 *
 	 * @var \GP_Locale The locale.
 	 */
-	protected $locale;
+	protected GP_Locale $locale;
 
 	/**
 	 * The current project.
@@ -60,7 +60,7 @@ class ZipProvider {
 	 *
 	 * @var \Required\Traduttore\Project The project.
 	 */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * ZipProvider constructor.
@@ -73,11 +73,12 @@ class ZipProvider {
 		$this->translation_set = $translation_set;
 		$this->locale          = GP_Locales::by_slug( $this->translation_set->locale );
 
+		/**
+		 * GlotPress project.
+		 *
+		 * @var \GP_Project $gp_project
+		 */
 		$gp_project = GP::$project->get( $this->translation_set->project_id );
-
-		if ( ! $gp_project ) {
-			throw new InvalidArgumentException( __( 'Project not found', 'traduttore' ) );
-		}
 
 		$this->project = new Project( $gp_project );
 	}

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -132,6 +132,10 @@ class ZipProvider {
 			}
 		}
 
+		if ( ! $wp_filesystem ) {
+			return false;
+		}
+
 		// Make sure the cache directory exists.
 		if ( ! is_dir( static::get_cache_dir() ) ) {
 			$wp_filesystem->mkdir( static::get_cache_dir(), FS_CHMOD_DIR );
@@ -211,6 +215,10 @@ class ZipProvider {
 			if ( ! \WP_Filesystem() ) {
 				return false;
 			}
+		}
+
+		if ( ! $wp_filesystem ) {
+			return false;
 		}
 
 		$success = $wp_filesystem->rmdir( $this->get_zip_path(), true );

--- a/inc/ZipProvider.php
+++ b/inc/ZipProvider.php
@@ -12,6 +12,7 @@ use DateTimeZone;
 use GP;
 use GP_Locales;
 use GP_Translation_Set;
+use http\Exception\InvalidArgumentException;
 use ZipArchive;
 
 /**
@@ -71,7 +72,14 @@ class ZipProvider {
 	public function __construct( GP_Translation_Set $translation_set ) {
 		$this->translation_set = $translation_set;
 		$this->locale          = GP_Locales::by_slug( $this->translation_set->locale );
-		$this->project         = new Project( GP::$project->get( $this->translation_set->project_id ) );
+
+		$gp_project = GP::$project->get( $this->translation_set->project_id );
+
+		if ( ! $gp_project ) {
+			throw new InvalidArgumentException( __( 'Project not found', 'traduttore' ) );
+		}
+
+		$this->project = new Project( $gp_project );
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,10 +2,19 @@
 <ruleset name="Coding Standard for Traduttore">
 	<description>Coding Standard for Traduttore</description>
 
-	<file>.</file>
-	<exclude-pattern>/tests/*</exclude-pattern>
+	<!-- Check for cross-version support for PHP 7.4 and higher. -->
+	<config name="testVersion" value="7.4-" />
 
-	<rule ref="Required"/>
+	<file>.</file>
+	<exclude-pattern>/tests/behat/*</exclude-pattern>
+	<exclude-pattern>/tests/features/*</exclude-pattern>
+	<exclude-pattern>/tests/phpstan/*</exclude-pattern>
+	<exclude-pattern>/tests/phpunit/data/*</exclude-pattern>
+	<exclude-pattern>/tests/phpunit/bootstrap.php</exclude-pattern>
+
+	<rule ref="Required">
+		<exclude-pattern>/tests/phpunit/tests</exclude-pattern>
+	</rule>
 
 	<rule ref="PSR1.Files.SideEffects">
 		<exclude-pattern>traduttore\.php</exclude-pattern>
@@ -18,6 +27,7 @@
 			</property>
 		</properties>
 	</rule>
+
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - tests/phpstan/bootstrap.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - tests/phpstan/bootstrap.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 8
+    level: 9
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - tests/phpstan/bootstrap.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,5 @@
-includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-# DREAM    level: max
-    level: 5
+    level: 6
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - tests/phpstan/bootstrap.php
@@ -16,6 +13,3 @@ parameters:
     paths:
         - inc/
 #        - test/
-    ignoreErrors:
-        # Uses func_get_args()
-        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,9 +7,11 @@ parameters:
         - vendor/wordpress-plugin/glotpress/gp-includes/routes/_main.php
     scanFiles:
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+        - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
     scanDirectories:
+        - tests/phpstan/stubs/
         - vendor/wordpress-plugin/glotpress/gp-includes/
         - vendor/wordpress-plugin/glotpress/locales/
     paths:
         - inc/
-#        - test/
+        - tests/phpunit

--- a/tests/behat/maybe-generate-wp-cli-coverage.php
+++ b/tests/behat/maybe-generate-wp-cli-coverage.php
@@ -12,8 +12,8 @@ if ( ! class_exists( 'SebastianBergmann\CodeCoverage\Filter' ) ) {
 }
 
 $filter = new Filter();
-$filter->includeDirectory( "{$root_folder}/includes" );
-$filter->includeDirectory( "{$root_folder}/src" );
+$filter->includeDirectory( "{$root_folder}/inc" );
+$filter->includeDirectory( "{$root_folder}/traduttore.php" );
 
 $coverage = new CodeCoverage(
 	( new Selector() )->forLineCoverage( $filter ),

--- a/tests/features/info.feature
+++ b/tests/features/info.feature
@@ -2,8 +2,9 @@
 Feature: Print various details about the environment.
 
   Background:
-    Given a WP installation with the Traduttore plugin
+    Given a WP installation
     And GlotPress develop being active
+    And Traduttore being active
 
   Scenario: Run info command
     When I run the WP-CLI command `traduttore info`

--- a/tests/features/project.feature
+++ b/tests/features/project.feature
@@ -2,8 +2,9 @@
 Feature: Print various details about the environment.
 
   Background:
-    Given a WP installation with the Traduttore plugin
+    Given a WP installation
     And GlotPress develop being active
+    And Traduttore being active
 
   Scenario: Run info command with invalid project ID
     When I try the WP-CLI command `traduttore project info 99999`

--- a/tests/features/testing.feature
+++ b/tests/features/testing.feature
@@ -1,11 +1,12 @@
 Feature: Test that the tests are working.
 
   Background:
-    Given a WP installation with the Traduttore plugin
+    Given a WP installation
 
   @require-php-7.4
   Scenario: Traduttore and GlotPress develop should be active.
     Given GlotPress develop being active
+    And Traduttore being active
 
     When I run `wp plugin status glotpress`
     Then STDOUT should contain:
@@ -31,6 +32,7 @@ Feature: Test that the tests are working.
 
   Scenario: Traduttore and GlotPress stable should be active.
     Given GlotPress stable being active
+    And Traduttore being active
 
     When I run `wp plugin status glotpress`
     Then STDOUT should contain:

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace {
-    define( 'WP_CONTENT_DIR', './' );
     define( 'GP_VERSION', '0.0.0' );
     define( 'WP_CLI_VERSION', '0.0.0' );
 }

--- a/tests/phpstan/stubs/factory.php
+++ b/tests/phpstan/stubs/factory.php
@@ -1,0 +1,129 @@
+<?php
+class GP_UnitTest_Factory extends WP_UnitTest_Factory {
+
+	/**
+	 * @var GP_UnitTest_Factory_For_Project
+	 */
+	public $project;
+
+	/**
+	 * @var GP_UnitTest_Factory_For_Original
+	 */
+	public $original;
+
+	/**
+	 * @var GP_UnitTest_Factory_For_Translation_Set
+	 */
+	public $translation_set;
+
+	/**
+	 * @var GP_UnitTest_Factory_For_Translation
+	 */
+	public $translation;
+
+	/**
+	 * @var GP_UnitTest_Factory_For_User
+	 */
+	public $user;
+
+	/**
+	 * @var GP_UnitTest_Factory_For_Locale
+	 */
+	public $locale;
+}
+
+class GP_UnitTest_Factory_For_Project extends GP_UnitTest_Factory_For_Thing {
+	/**
+	 * @param array $args
+	 * @param array $generation_definitions
+	 *
+	 * @return \GP_Project
+	 */
+	function create( $args = [], $generation_definitions = null ) {
+	}
+}
+
+class GP_UnitTest_Factory_For_User extends WP_UnitTest_Factory_For_User {
+
+	/**
+	 * @param array $args
+	 *
+	 * @return int
+	 */
+	function create_admin( $args = [] ) {
+	}
+}
+
+
+class GP_UnitTest_Factory_For_Translation_Set extends GP_UnitTest_Factory_For_Thing {
+
+	/**
+	 * @param array $args
+	 * @param array $project_args
+	 *
+	 * @return \GP_Translation_Set
+	 */
+	function create_with_project( $args = [], $project_args = [] ) {
+	}
+
+	/**
+	 * @param array $args
+	 * @param array $project_args
+	 *
+	 * @return \GP_Translation_Set
+	 */
+	function create_with_project_and_locale( $args = [], $project_args = [] ) {
+	}
+}
+
+class GP_UnitTest_Factory_For_Original extends GP_UnitTest_Factory_For_Thing {
+	/**
+	 * @param array $args
+	 * @param array $generation_definitions
+	 *
+	 * @return \GP_Original
+	 */
+	function create( $args = [], $generation_definitions = null ) {
+	}
+}
+
+class GP_UnitTest_Factory_For_Translation extends GP_UnitTest_Factory_For_Thing {
+	/**
+	 * @param GP_Translation_Set $set
+	 * @param array $args
+	 *
+	 * @return \GP_Translation
+	 */
+	function create_with_original_for_translation_set( $set, $args = [] ) {
+	}
+}
+
+class GP_UnitTest_Factory_For_Locale extends GP_UnitTest_Factory_For_Thing {
+
+	/**
+	 * @param GP_Translation_Set $set
+	 * @param array $generation_definitions
+	 *
+	 * @return \GP_Locale
+	 */
+	function create( $args = [], $generation_definitions = null ) {
+	}
+}
+
+class GP_UnitTest_Factory_For_Glossary extends GP_UnitTest_Factory_For_Thing {
+	/**
+	 * @param array $args
+	 * @param array $project_args
+	 *
+	 * @return \GP_Glossary
+	 */
+	function create_with_project_set_and_locale( $args = [], $project_args = [] ) {
+	}
+}
+
+
+class GP_UnitTest_Factory_For_Thing {
+
+	function create( $args = [], $generation_definitions = null ) {
+	}
+}

--- a/tests/phpstan/stubs/test-stubs.php
+++ b/tests/phpstan/stubs/test-stubs.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @param callable $callback
+ * @param array $args
+ *
+ * @return string
+ */
+function get_echo( $callback, array $args = [] ) {
+	ob_start();
+	call_user_func_array( $callback, $args );
+	return ob_get_clean();
+}

--- a/tests/phpstan/stubs/testcase-route.php
+++ b/tests/phpstan/stubs/testcase-route.php
@@ -1,0 +1,55 @@
+<?php
+
+class GP_UnitTestCase_Route extends GP_UnitTestCase {
+	/**
+	 * @var GP_Route
+	 */
+	var $route;
+
+	/**
+	 * @var GP_Route::class
+	 */
+	var $route_class;
+
+	function assertRedirected() {
+	}
+
+	function assertRedirectURLContains( $text ) {
+	}
+
+	function assertThereIsAnErrorContaining( $text ) {
+	}
+
+	function assertThereIsANoticeContaining( $text ) {
+	}
+
+	function assertThereIsAnArrayElementContaining( $text, $array, $message = null ) {
+	}
+
+	function assertNotAllowedRedirect() {
+	}
+
+	function assertInvalidNonceRedirect() {
+	}
+
+	function assertInvalidRedirect() {
+	}
+
+	function assertErrorRedirect() {
+	}
+
+	function assertTemplateLoadedIs( $template ) {
+	}
+
+	function assertTemplateOutputNotEmpty() {
+	}
+
+	function assert404() {
+	}
+
+	/**
+	 * Parses and returns the API response.
+	 */
+	function api_response() {
+	}
+}

--- a/tests/phpstan/stubs/testcase.php
+++ b/tests/phpstan/stubs/testcase.php
@@ -1,0 +1,68 @@
+<?php
+
+class GP_UnitTestCase extends WP_UnitTestCase {
+
+	/**
+	 * @var string
+	 */
+	public $url = 'http://example.org/';
+
+	/**
+	 * @var GP_UnitTest_Factory
+	 */
+	public $factory;
+
+	function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new GP_UnitTest_Factory();
+
+		global $wp_rewrite;
+		if ( GP_TESTS_PERMALINK_STRUCTURE != $wp_rewrite->permalink_structure ) {
+			$this->set_permalink_structure( GP_TESTS_PERMALINK_STRUCTURE );
+		}
+	}
+
+	/**
+	 * Utility method that resets permalinks and flushes rewrites.
+	 *
+	 * Also updates the pre_option filter for `permalink_structure`.
+	 *
+	 * @global WP_Rewrite $wp_rewrite
+	 *
+	 * @param string $structure Optional. Permalink structure to set. Default empty.
+	 */
+	public function set_permalink_structure( $structure = '' ) {
+		global $wp_tests_options;
+
+		$wp_tests_options['permalink_structure'] = $structure;
+
+		parent::set_permalink_structure( $structure );
+	}
+
+	function clean_up_global_scope() {
+		parent::clean_up_global_scope();
+
+		$locales = &GP_Locales::instance();
+		$locales->locales = [];
+		$_GET = [];
+		$_POST = [];
+		/**
+		 * @todo re-initialize all thing objects
+		 */
+		GP::$translation_set = new GP_Translation_Set;
+		GP::$original = new GP_Original;
+	}
+
+	function set_normal_user_as_current() {
+		$user = $this->factory->user->create();
+		wp_set_current_user( $user );
+		return $user;
+	}
+
+	function set_admin_user_as_current() {
+		$admin = $this->factory->user->create_admin();
+		wp_set_current_user( $admin );
+		return $admin;
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * PHPUnit bootstrap file
- *
- * @package Required\Traduttore
  */
 
 $_tests_dir    = getenv( 'WP_TESTS_DIR' );
@@ -32,7 +30,7 @@ require_once $_tests_dir . '/includes/functions.php';
 
 tests_add_filter(
 	'muplugins_loaded',
-	function() use ( $_gp_tests_dir ) {
+	function () use ( $_gp_tests_dir ): void {
 		require_once $_gp_tests_dir . '/includes/loader.php';
 
 		require dirname( __DIR__, 2 ) . '/traduttore.php';

--- a/tests/phpunit/tests/Behat/FeatureContext.php
+++ b/tests/phpunit/tests/Behat/FeatureContext.php
@@ -67,11 +67,9 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 	}
 
 	/**
-	 * @Given a WP install(ation) with the Traduttore plugin
+	 * @Given Traduttore being active
 	 */
-	public function given_a_wp_installation_with_the_traduttore_plugin(): void {
-		$this->install_wp();
-
+	public function given_traduttore_being_active(): void {
 		// Symlink the current project folder into the WP folder as a plugin.
 		$project_dir = realpath( self::get_vendor_dir() . '/../' );
 		$plugin_dir  = $this->variables['RUN_DIR'] . '/wp-content/plugins';

--- a/tests/phpunit/tests/Behat/FeatureContext.php
+++ b/tests/phpunit/tests/Behat/FeatureContext.php
@@ -85,7 +85,7 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 	/**
 	 * @Given /^GlotPress (.*) being active$/
 	 */
-	public function given_the_glotpress_plugin_being_active( $gp_version ): void {
+	public function given_the_glotpress_plugin_being_active( string $gp_version ): void {
 		$branch_name = $gp_version;
 		if ( 'nightly' === $gp_version || 'develop' === $gp_version || 'trunk' === $gp_version ) {
 			$branch_name = 'develop';
@@ -120,7 +120,7 @@ PHPCODE;
 	/**
 	 * @When /^I (run|try) the WP-CLI command `([^`]+)`$/
 	 */
-	public function when_i_run_the_wp_cli_command( $mode, $command ): void {
+	public function when_i_run_the_wp_cli_command( string $mode, string $command ): void {
 		$command = "wp {$command}";
 
 		$with_code_coverage = getenv( 'BEHAT_CODE_COVERAGE' );
@@ -135,8 +135,8 @@ PHPCODE;
 				$command,
 				[
 					'BEHAT_PROJECT_DIR'    => $this->variables['PROJECT_DIR'],
-					'BEHAT_FEATURE_TITLE'  => self::$feature->getTitle(),
-					'BEHAT_SCENARIO_TITLE' => $this->scenario->getTitle(),
+					'BEHAT_FEATURE_TITLE'  => self::$feature ? self::$feature->getTitle() : null,
+					'BEHAT_SCENARIO_TITLE' => $this->scenario ? $this->scenario->getTitle() : null,
 				]
 			),
 			$mode
@@ -150,7 +150,7 @@ PHPCODE;
 	 *
 	 * @param string $directory Directory to ensure the existence of.
 	 */
-	private function ensure_dir_exists( $directory ): void {
+	private function ensure_dir_exists( string $directory ): void {
 		$parent = dirname( $directory );
 
 		if ( ! empty( $parent ) && ! is_dir( $parent ) ) {
@@ -165,11 +165,11 @@ PHPCODE;
 	/**
 	 * Create a new process with added environment variables.
 	 *
-	 * @param string $command Command to run.
-	 * @param array  $env     Associative array of environment variables to add.
+	 * @param string                $command Command to run.
+	 * @param array<string, string> $env     Associative array of environment variables to add.
 	 * @return \WP_CLI\Process Process to execute.
 	 */
-	public function proc_with_env( $command, $env = [] ): Process {
+	public function proc_with_env( string $command, array $env = [] ): Process {
 		$env = array_merge(
 			self::get_process_env_variables(),
 			$env
@@ -192,6 +192,8 @@ PHPCODE;
 	 * Get the environment variables required for launched `wp` processes.
 	 *
 	 * This is copied over from WP_CLI\Tests\Context\FeatureContext, to enable an adaption of FeatureContext::proc().
+	 *
+	 * @return array<string, string|int>
 	 */
 	private static function get_process_env_variables(): array {
 		// Ensure we're using the expected `wp` binary.

--- a/tests/phpunit/tests/Configuration.php
+++ b/tests/phpunit/tests/Configuration.php
@@ -1,38 +1,37 @@
 <?php
 /**
  * Class Configuration
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use \Required\Traduttore\Configuration as Config;
+use Required\Traduttore\Configuration as Config;
 
 /**
  * Test cases for \Required\Traduttore\Configuration.
  */
 class Configuration extends TestCase {
 	public function test_get_path(): void {
-		$config = new Config( dirname( __DIR__ ) . '/data/example-no-config' );
+		$config = new Config( \dirname( __DIR__ ) . '/data/example-no-config' );
 
-		$this->assertSame( dirname( __DIR__ ) . '/data/example-no-config', $config->get_path() );
+		$this->assertSame( \dirname( __DIR__ ) . '/data/example-no-config', $config->get_path() );
 	}
 
 	public function test_get_config_empty_directory(): void {
-		$config = new Config( dirname( __DIR__ ) . '/data/example-no-config' );
+		$config = new Config( \dirname( __DIR__ ) . '/data/example-no-config' );
 
 		$this->assertEmpty( $config->get_config() );
 	}
 
 	public function test_get_config_value_empty_directory(): void {
-		$config = new Config( dirname( __DIR__ ) . '/data/example-no-config' );
+		$config = new Config( \dirname( __DIR__ ) . '/data/example-no-config' );
 
+		// @phpstan-ignore-next-line
 		$this->assertNull( $config->get_config_value( 'foo' ) );
 	}
 
 	public function test_get_config_composer(): void {
-		$config = new Config( dirname( __DIR__ ) . '/data/example-with-composer' );
+		$config = new Config( \dirname( __DIR__ ) . '/data/example-with-composer' );
 
 		$this->assertEqualSets(
 			[
@@ -48,7 +47,7 @@ class Configuration extends TestCase {
 	}
 
 	public function test_get_config_traduttore(): void {
-		$config = new Config( dirname( __DIR__ ) . '/data/example-with-config' );
+		$config = new Config( \dirname( __DIR__ ) . '/data/example-with-config' );
 
 		$this->assertEqualSets(
 			[

--- a/tests/phpunit/tests/Export.php
+++ b/tests/phpunit/tests/Export.php
@@ -1,29 +1,26 @@
 <?php
 /**
  * Class Export
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use GP_Translation_Set;
 use PO;
-use \Required\Traduttore\Export as E;
+use Required\Traduttore\Export as E;
 
 /**
  * Test cases for \Required\Traduttore\Export.
  */
 class Export extends TestCase {
 	/**
-	 * @var GP_Translation_Set
+	 * @var \GP_Translation_Set
 	 */
 	protected $translation_set;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$locale = $this->factory->locale->create(
+		$locale = $this->factory()->locale->create(
 			[
 				'english_name' => 'German',
 				'native_name'  => 'Deutsch',
@@ -32,7 +29,7 @@ class Export extends TestCase {
 			]
 		);
 
-		$this->translation_set = $this->factory->translation_set->create_with_project(
+		$this->translation_set = $this->factory()->translation_set->create_with_project(
 			[
 				'locale' => $locale->slug,
 			],
@@ -49,14 +46,14 @@ class Export extends TestCase {
 	}
 
 	public function test_creates_only_po_and_mo_files(): void {
-		$original = $this->factory->original->create(
+		$original = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => 'my-plugin.php',
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -67,6 +64,8 @@ class Export extends TestCase {
 		$export = new E( $this->translation_set );
 
 		$actual = $export->export_strings();
+
+		$this->assertIsArray( $actual );
 
 		array_map( 'unlink', $actual );
 
@@ -85,7 +84,7 @@ class Export extends TestCase {
 		$filename_2 = 'my-super-minified-script';
 
 		/* @var \GP_Original $original_1 */
-		$original_1 = $this->factory->original->create(
+		$original_1 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_1 . '.js',
@@ -93,14 +92,14 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_2 */
-		$original_2 = $this->factory->original->create(
+		$original_2 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_2 . '.min.js',
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_1->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -108,7 +107,7 @@ class Export extends TestCase {
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_2->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -120,6 +119,8 @@ class Export extends TestCase {
 
 		$actual = $export->export_strings();
 
+		$this->assertIsArray( $actual );
+
 		$json_filename_1 = 'foo-project-de_DE-' . md5( $filename_1 . '.js' ) . '.json';
 		$json_filename_2 = 'foo-project-de_DE-' . md5( $filename_2 . '.js' ) . '.json';
 
@@ -128,6 +129,8 @@ class Export extends TestCase {
 
 		array_map( 'unlink', $actual );
 
+		$this->assertIsString( $json_1 );
+		$this->assertIsString( $json_2 );
 		$this->assertJson( $json_1 );
 		$this->assertJson( $json_2 );
 		$this->assertEqualSets(
@@ -145,9 +148,8 @@ class Export extends TestCase {
 	/**
 	 * Modify the mapping of sources to translation entries.
 	 *
-	 * @param array $mapping The mapping of sources to translation entries.
-	 *
-	 * @return array The maybe modified mapping.
+	 * @param array<string, \Translation_Entry[]> $mapping The mapping of sources to translation entries.
+	 * @return array<string, \Required\Traduttore\Tests\Translation_Entry[]> The maybe modified mapping.
 	 */
 	public function filter_map_entries_to_source( array $mapping ): array {
 		$mapping['build.js'] = array_merge( $mapping['my-super-script.js'], $mapping['my-other-script.js'] );
@@ -163,7 +165,7 @@ class Export extends TestCase {
 		$filename_target = 'build.js';
 
 		/* @var \GP_Original $original_1 */
-		$original_1 = $this->factory->original->create(
+		$original_1 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_1,
@@ -171,14 +173,14 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_2 */
-		$original_2 = $this->factory->original->create(
+		$original_2 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_2,
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_1->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -186,7 +188,7 @@ class Export extends TestCase {
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_2->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -199,6 +201,8 @@ class Export extends TestCase {
 		add_filter( 'traduttore.map_entries_to_source', [ $this, 'filter_map_entries_to_source' ] );
 
 		$actual = $export->export_strings();
+
+		$this->assertIsArray( $actual );
 
 		remove_filter( 'traduttore.map_entries_to_source', [ $this, 'filter_map_entries_to_source' ] );
 
@@ -213,6 +217,7 @@ class Export extends TestCase {
 
 		array_map( 'unlink', $actual );
 
+		$this->assertIsString( $json );
 		$this->assertJson( $json );
 		$this->assertEqualSets(
 			[
@@ -230,7 +235,7 @@ class Export extends TestCase {
 		$filename_2 = 'my-super-minified-script';
 
 		/* @var \GP_Original $original_1 */
-		$original_1 = $this->factory->original->create(
+		$original_1 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_1 . '.js',
@@ -238,7 +243,7 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_2 */
-		$original_2 = $this->factory->original->create(
+		$original_2 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_2 . '.min.js',
@@ -246,28 +251,28 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_3 */
-		$original_3 = $this->factory->original->create(
+		$original_3 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => 'foo.php',
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_1->id,
 				'translation_set_id' => $this->translation_set->id,
 				'status'             => 'current',
 			]
 		);
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_2->id,
 				'translation_set_id' => $this->translation_set->id,
 				'status'             => 'current',
 			]
 		);
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_3->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -279,14 +284,19 @@ class Export extends TestCase {
 
 		$actual = $export->export_strings();
 
+		$this->assertIsArray( $actual );
+
 		$translations = new PO();
 		$translations->import_from_file( $actual['foo-project-de_DE.po'] );
 
 		$json_filename_1 = 'foo-project-de_DE-' . md5( $filename_1 . '.js' ) . '.json';
 		$json_filename_2 = 'foo-project-de_DE-' . md5( $filename_2 . '.js' ) . '.json';
 
-		$json_1 = json_decode( file_get_contents( $actual[ $json_filename_1 ] ), true );
-		$json_2 = json_decode( file_get_contents( $actual[ $json_filename_2 ] ), true );
+		$json_1 = json_decode( (string) file_get_contents( $actual[ $json_filename_1 ] ), true );
+		$json_2 = json_decode( (string) file_get_contents( $actual[ $json_filename_2 ] ), true );
+
+		$this->assertIsArray( $json_1 );
+		$this->assertIsArray( $json_2 );
 
 		array_map( 'unlink', $actual );
 
@@ -304,7 +314,7 @@ class Export extends TestCase {
 		$filename_3 = 'dist/build.js';
 
 		/* @var \GP_Original $original_1 */
-		$original_1 = $this->factory->original->create(
+		$original_1 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => "$filename_1 $filename_3",
@@ -312,7 +322,7 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_2 */
-		$original_2 = $this->factory->original->create(
+		$original_2 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => "$filename_2 $filename_3",
@@ -320,28 +330,28 @@ class Export extends TestCase {
 		);
 
 		/* @var \GP_Original $original_3 */
-		$original_3 = $this->factory->original->create(
+		$original_3 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_3,
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_1->id,
 				'translation_set_id' => $this->translation_set->id,
 				'status'             => 'current',
 			]
 		);
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_2->id,
 				'translation_set_id' => $this->translation_set->id,
 				'status'             => 'current',
 			]
 		);
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_3->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -353,9 +363,11 @@ class Export extends TestCase {
 
 		$actual = $export->export_strings();
 
+		$this->assertIsArray( $actual );
+
 		$json_filename = 'foo-project-de_DE-' . md5( $filename_3 ) . '.json';
 
-		$json = json_decode( file_get_contents( $actual[ $json_filename ] ), true );
+		$json = json_decode( (string) file_get_contents( $actual[ $json_filename ] ), true );
 
 		array_map( 'unlink', $actual );
 
@@ -379,14 +391,14 @@ class Export extends TestCase {
 		$filename_1 = 'my-super-script';
 
 		/* @var \GP_Original $original_1 */
-		$original_1 = $this->factory->original->create(
+		$original_1 = $this->factory()->original->create(
 			[
 				'project_id' => $this->translation_set->project_id,
 				'references' => $filename_1 . '.js',
 			]
 		);
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original_1->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -398,15 +410,18 @@ class Export extends TestCase {
 
 		$actual = $export->export_strings();
 
+		$this->assertIsArray( $actual );
+
 		$json_filename_1 = 'foo-project-de_DE-' . md5( $filename_1 . '.js' ) . '.json';
 
 		$json_1 = file_get_contents( $actual[ $json_filename_1 ] );
 
 		array_map( 'unlink', $actual );
 
+		$this->assertIsString( $json_1 );
 		$this->assertJson( $json_1 );
 
-		$json1_encoded = json_decode( $json_1 );
+		$json1_encoded = (object) json_decode( $json_1 );
 		$this->assertSame( $filename_1 . '.js', $json1_encoded->comment->reference );
 	}
 }

--- a/tests/phpunit/tests/Export.php
+++ b/tests/phpunit/tests/Export.php
@@ -74,6 +74,7 @@ class Export extends TestCase {
 			[
 				'foo-project-de_DE.po',
 				'foo-project-de_DE.mo',
+				'foo-project-de_DE.l10n.php',
 			],
 			array_keys( $actual )
 		);
@@ -133,6 +134,7 @@ class Export extends TestCase {
 			[
 				'foo-project-de_DE.po',
 				'foo-project-de_DE.mo',
+				'foo-project-de_DE.l10n.php',
 				$json_filename_1,
 				$json_filename_2,
 			],
@@ -216,6 +218,7 @@ class Export extends TestCase {
 			[
 				'foo-project-de_DE.po',
 				'foo-project-de_DE.mo',
+				'foo-project-de_DE.l10n.php',
 				$json_filename_target,
 			],
 			array_keys( $actual )
@@ -356,7 +359,7 @@ class Export extends TestCase {
 
 		array_map( 'unlink', $actual );
 
-		$this->assertInternalType( 'array', $json );
+		$this->assertIsArray( $json );
 		$this->assertCount( 4, $json['locale_data']['messages'] );
 		$this->assertArrayHasKey( $original_1->singular, $json['locale_data']['messages'] );
 		$this->assertArrayHasKey( $original_2->singular, $json['locale_data']['messages'] );
@@ -365,6 +368,7 @@ class Export extends TestCase {
 			[
 				'foo-project-de_DE.po',
 				'foo-project-de_DE.mo',
+				'foo-project-de_DE.l10n.php',
 				$json_filename,
 			],
 			array_keys( $actual )

--- a/tests/phpunit/tests/Export.php
+++ b/tests/phpunit/tests/Export.php
@@ -12,10 +12,7 @@ use Required\Traduttore\Export as E;
  * Test cases for \Required\Traduttore\Export.
  */
 class Export extends TestCase {
-	/**
-	 * @var \GP_Translation_Set
-	 */
-	protected $translation_set;
+	protected \GP_Translation_Set $translation_set;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -149,7 +146,7 @@ class Export extends TestCase {
 	 * Modify the mapping of sources to translation entries.
 	 *
 	 * @param array<string, \Translation_Entry[]> $mapping The mapping of sources to translation entries.
-	 * @return array<string, \Required\Traduttore\Tests\Translation_Entry[]> The maybe modified mapping.
+	 * @return array<string, \Translation_Entry[]> The maybe modified mapping.
 	 */
 	public function filter_map_entries_to_source( array $mapping ): array {
 		$mapping['build.js'] = array_merge( $mapping['my-super-script.js'], $mapping['my-other-script.js'] );

--- a/tests/phpunit/tests/Loader/Git.php
+++ b/tests/phpunit/tests/Loader/Git.php
@@ -16,10 +16,7 @@ use Required\Traduttore\Tests\TestCase;
  * @todo Mock shell execution
  */
 class Git extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\Loader\Project
-	 */
-	protected $project;
+	protected Project $project;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/Loader/Git.php
+++ b/tests/phpunit/tests/Loader/Git.php
@@ -7,7 +7,6 @@
 
 namespace Required\Traduttore\Tests\Loader;
 
-use \GP_UnitTestCase;
 use \Required\Traduttore\Loader\Git as GitLoader;
 use \Required\Traduttore\Project;
 use Required\Traduttore\Repository\GitHub;

--- a/tests/phpunit/tests/Loader/Git.php
+++ b/tests/phpunit/tests/Loader/Git.php
@@ -24,7 +24,7 @@ class Git extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Loader/Git.php
+++ b/tests/phpunit/tests/Loader/Git.php
@@ -1,14 +1,12 @@
 <?php
 /**
  * Class Git
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Loader;
 
-use \Required\Traduttore\Loader\Git as GitLoader;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Loader\Git as GitLoader;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository\GitHub;
 use Required\Traduttore\Tests\TestCase;
 
@@ -19,7 +17,7 @@ use Required\Traduttore\Tests\TestCase;
  */
 class Git extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Tests\Loader\Project
 	 */
 	protected $project;
 
@@ -27,7 +25,7 @@ class Git extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'slug'                => 'sample-project',
@@ -44,8 +42,9 @@ class Git extends TestCase {
 	}
 
 	public function test_download_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new GitLoader( new GitHub( $this->project ) );
 
 		add_filter( 'traduttore.git_clone_use_https', '__return_true' );
@@ -56,8 +55,9 @@ class Git extends TestCase {
 	}
 
 	public function test_download_existing_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new GitLoader( new GitHub( $this->project ) );
 
 		add_filter( 'traduttore.git_clone_use_https', '__return_true' );

--- a/tests/phpunit/tests/Loader/Mercurial.php
+++ b/tests/phpunit/tests/Loader/Mercurial.php
@@ -16,10 +16,7 @@ use Required\Traduttore\Tests\TestCase;
  * @todo Mock shell execution
  */
 class Mercurial extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\Loader\Project
-	 */
-	protected $project;
+	protected Project $project;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/Loader/Mercurial.php
+++ b/tests/phpunit/tests/Loader/Mercurial.php
@@ -1,14 +1,12 @@
 <?php
 /**
  * Class Mercurial
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Loader;
 
-use \Required\Traduttore\Loader\Mercurial as MercurialLoader;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Loader\Mercurial as MercurialLoader;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository\Bitbucket;
 use Required\Traduttore\Tests\TestCase;
 
@@ -19,7 +17,7 @@ use Required\Traduttore\Tests\TestCase;
  */
 class Mercurial extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Tests\Loader\Project
 	 */
 	protected $project;
 
@@ -27,7 +25,7 @@ class Mercurial extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'slug'                => 'sample-project',
@@ -44,8 +42,9 @@ class Mercurial extends TestCase {
 	}
 
 	public function test_download_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new MercurialLoader( new Bitbucket( $this->project ) );
 
 		add_filter( 'traduttore.hg_clone_use_https', '__return_true' );
@@ -56,8 +55,9 @@ class Mercurial extends TestCase {
 	}
 
 	public function test_download_existing_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new MercurialLoader( new Bitbucket( $this->project ) );
 
 		add_filter( 'traduttore.hg_clone_use_https', '__return_true' );

--- a/tests/phpunit/tests/Loader/Mercurial.php
+++ b/tests/phpunit/tests/Loader/Mercurial.php
@@ -24,7 +24,7 @@ class Mercurial extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Loader/Mercurial.php
+++ b/tests/phpunit/tests/Loader/Mercurial.php
@@ -7,7 +7,6 @@
 
 namespace Required\Traduttore\Tests\Loader;
 
-use \GP_UnitTestCase;
 use \Required\Traduttore\Loader\Mercurial as MercurialLoader;
 use \Required\Traduttore\Project;
 use Required\Traduttore\Repository\Bitbucket;

--- a/tests/phpunit/tests/Loader/Subversion.php
+++ b/tests/phpunit/tests/Loader/Subversion.php
@@ -1,14 +1,12 @@
 <?php
 /**
  * Class Subversion
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Loader;
 
-use \Required\Traduttore\Loader\Subversion as SubversionLoader;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Loader\Subversion as SubversionLoader;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository\Bitbucket;
 use Required\Traduttore\Tests\TestCase;
 
@@ -19,7 +17,7 @@ use Required\Traduttore\Tests\TestCase;
  */
 class Subversion extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Tests\Loader\Project
 	 */
 	protected $project;
 
@@ -27,7 +25,7 @@ class Subversion extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'slug'                => 'sample-project',
@@ -44,8 +42,9 @@ class Subversion extends TestCase {
 	}
 
 	public function test_download_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new SubversionLoader( new Bitbucket( $this->project ) );
 
 		add_filter( 'traduttore.svn_checkout_use_https', '__return_true' );
@@ -56,8 +55,9 @@ class Subversion extends TestCase {
 	}
 
 	public function test_download_existing_repository(): void {
-		$this->markTestSkipped( 'Need to mock shell command execution' );
+		$this->markTestIncomplete( 'Need to mock shell command execution' );
 
+		// @phpstan-ignore-next-line
 		$loader = new SubversionLoader( new Bitbucket( $this->project ) );
 
 		add_filter( 'traduttore.svn_checkout_use_https', '__return_true' );

--- a/tests/phpunit/tests/Loader/Subversion.php
+++ b/tests/phpunit/tests/Loader/Subversion.php
@@ -16,10 +16,7 @@ use Required\Traduttore\Tests\TestCase;
  * @todo Mock shell execution
  */
 class Subversion extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\Loader\Project
-	 */
-	protected $project;
+	protected Project $project;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/Loader/Subversion.php
+++ b/tests/phpunit/tests/Loader/Subversion.php
@@ -23,7 +23,7 @@ class Subversion extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/LoaderFactory.php
+++ b/tests/phpunit/tests/LoaderFactory.php
@@ -1,16 +1,16 @@
 <?php
 /**
  * Class LoaderFactory
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use Required\Traduttore\Loader\{Git, Mercurial};
-use \Required\Traduttore\Project;
-use \Required\Traduttore\Repository;
-use \Required\Traduttore\LoaderFactory as Factory;
+use Required\Traduttore\Loader\Git;
+use Required\Traduttore\Loader\Mercurial;
+
+use Required\Traduttore\Project;
+use Required\Traduttore\Repository;
+use Required\Traduttore\LoaderFactory as Factory;
 use Required\Traduttore\Repository\Bitbucket;
 use Required\Traduttore\Repository\GitHub;
 use Required\Traduttore\Repository\GitLab;
@@ -22,7 +22,7 @@ class LoaderFactory extends TestCase {
 	public function test_get_mercurial_loader(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -39,7 +39,7 @@ class LoaderFactory extends TestCase {
 	public function test_get_git_loader_for_bitbucket_repository(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -54,7 +54,7 @@ class LoaderFactory extends TestCase {
 	public function test_get_git_loader_for_github_repository(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -69,7 +69,7 @@ class LoaderFactory extends TestCase {
 	public function test_get_git_loader_for_gitlab_repository(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -1,34 +1,31 @@
 <?php
 /**
  * Project class.
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
 use DateTime;
 use DateTimeZone;
-use \GP_Project;
-use \Required\Traduttore\Project as TraduttoreProject;
+use Required\Traduttore\Project as TraduttoreProject;
 
 /**
  * Test cases for \Required\Traduttore\Project.
  */
 class Project extends TestCase {
 	/**
-	 * @var GP_Project
+	 * @var \Required\Traduttore\Tests\GP_Project
 	 */
 	protected $gp_project;
 	/**
-	 * @var TraduttoreProject
+	 * @var \Required\Traduttore\Tests\TraduttoreProject
 	 */
 	protected $project;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->gp_project = $this->factory->project->create(
+		$this->gp_project = $this->factory()->project->create(
 			[
 				'name'   => 'Project',
 				'active' => 1,
@@ -159,7 +156,7 @@ class Project extends TestCase {
 		$this->project->set_last_updated_time( $time );
 
 		$this->assertInstanceOf( DateTime::class, $this->project->get_last_updated_time() );
-		$this->assertSame( $time->getTimestamp(), $this->project->get_last_updated_time()->getTimestamp(), 'Last updated time is not identical', 1 );
+		$this->assertSame( $time->getTimestamp(), $this->project->get_last_updated_time()->getTimestamp(), 'Last updated time is not identical' );
 	}
 
 	public function test_get_repository_webhook_secret(): void {

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -8,6 +8,7 @@
 namespace Required\Traduttore\Tests;
 
 use DateTime;
+use DateTimeZone;
 use \GP_Project;
 use \Required\Traduttore\Project as TraduttoreProject;
 
@@ -24,7 +25,7 @@ class Project extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->gp_project = $this->factory->project->create(
@@ -153,12 +154,12 @@ class Project extends TestCase {
 	}
 
 	public function test_get_last_updated_time(): void {
-		$time = new DateTime( 'now' );
+		$time = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
 		$this->project->set_last_updated_time( $time );
 
 		$this->assertInstanceOf( DateTime::class, $this->project->get_last_updated_time() );
-		$this->assertEquals( $time, $this->project->get_last_updated_time(), 'Last updated time is not identical', 1 );
+		$this->assertSame( $time->getTimestamp(), $this->project->get_last_updated_time()->getTimestamp(), 'Last updated time is not identical', 1 );
 	}
 
 	public function test_get_repository_webhook_secret(): void {

--- a/tests/phpunit/tests/Project.php
+++ b/tests/phpunit/tests/Project.php
@@ -7,20 +7,16 @@ namespace Required\Traduttore\Tests;
 
 use DateTime;
 use DateTimeZone;
+use GP_Project;
 use Required\Traduttore\Project as TraduttoreProject;
 
 /**
  * Test cases for \Required\Traduttore\Project.
  */
 class Project extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\GP_Project
-	 */
-	protected $gp_project;
-	/**
-	 * @var \Required\Traduttore\Tests\TraduttoreProject
-	 */
-	protected $project;
+	protected GP_Project $gp_project;
+
+	protected TraduttoreProject $project;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -56,12 +56,6 @@ class ProjectLocator extends TestCase {
 		$this->assertNull( $locator->get_project() );
 	}
 
-	public function test_false(): void {
-		$locator = new Locator( false );
-
-		$this->assertNull( $locator->get_project() );
-	}
-
 	public function test_invalid_project_id(): void {
 		$locator = new Locator( 0 );
 

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -29,7 +29,7 @@ class ProjectLocator extends TestCase {
 	 */
 	protected $subsub;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->root   = $this->factory->project->create(
@@ -81,43 +81,43 @@ class ProjectLocator extends TestCase {
 		$project = $this->root;
 		$locator = new Locator( $project );
 
-		$this->assertEquals( $this->root->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->root->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_path(): void {
 		$locator = new Locator( 'root' );
 
-		$this->assertEquals( $this->root->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->root->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_subpath(): void {
 		$locator = new Locator( 'root/sub' );
 
-		$this->assertEquals( $this->sub->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_subsubpath(): void {
 		$locator = new Locator( 'root/sub/subsub' );
 
-		$this->assertEquals( $this->subsub->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->subsub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_id(): void {
 		$locator = new Locator( (int) $this->sub->id );
 
-		$this->assertEquals( $this->sub->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_id_as_string(): void {
 		$locator = new Locator( (string) $this->sub->id );
 
-		$this->assertEquals( $this->sub->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_github_url(): void {
 		$locator = new Locator( 'https://github.com/wearerequired/traduttore' );
 
-		$this->assertEquals( $this->subsub->id, $locator->get_project()->get_id() );
+		$this->assertSame( $this->subsub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_repository_name(): void {
@@ -133,7 +133,7 @@ class ProjectLocator extends TestCase {
 
 		$locator = new Locator( 'wearerequired/traduttore-registry' );
 
-		$this->assertEquals( $project->get_id(), $locator->get_project()->get_id() );
+		$this->assertSame( $project->get_id(), $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_repository_url(): void {
@@ -149,6 +149,6 @@ class ProjectLocator extends TestCase {
 
 		$locator = new Locator( 'https://github.com/wearerequired/traduttore-registry' );
 
-		$this->assertEquals( $project->get_id(), $locator->get_project()->get_id() );
+		$this->assertSame( $project->get_id(), $locator->get_project()->get_id() );
 	}
 }

--- a/tests/phpunit/tests/ProjectLocator.php
+++ b/tests/phpunit/tests/ProjectLocator.php
@@ -1,14 +1,12 @@
 <?php
 /**
  * Class ProjectLocator
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use \Required\Traduttore\Project;
-use \Required\Traduttore\ProjectLocator as Locator;
+use Required\Traduttore\Project;
+use Required\Traduttore\ProjectLocator as Locator;
 
 /**
  * Test cases for \Required\Traduttore\ProjectLocator.
@@ -32,18 +30,18 @@ class ProjectLocator extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->root   = $this->factory->project->create(
+		$this->root   = $this->factory()->project->create(
 			[
 				'name' => 'Root',
 			]
 		);
-		$this->sub    = $this->factory->project->create(
+		$this->sub    = $this->factory()->project->create(
 			[
 				'name'              => 'Sub',
 				'parent_project_id' => $this->root->id,
 			]
 		);
-		$this->subsub = $this->factory->project->create(
+		$this->subsub = $this->factory()->project->create(
 			[
 				'name'                => 'SubSub',
 				'parent_project_id'   => $this->sub->id,
@@ -81,48 +79,55 @@ class ProjectLocator extends TestCase {
 		$project = $this->root;
 		$locator = new Locator( $project );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->root->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_path(): void {
 		$locator = new Locator( 'root' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->root->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_subpath(): void {
 		$locator = new Locator( 'root/sub' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_subsubpath(): void {
 		$locator = new Locator( 'root/sub/subsub' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->subsub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_id(): void {
 		$locator = new Locator( (int) $this->sub->id );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_glotpress_id_as_string(): void {
 		$locator = new Locator( (string) $this->sub->id );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->sub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_github_url(): void {
 		$locator = new Locator( 'https://github.com/wearerequired/traduttore' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $this->subsub->id, $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_repository_name(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Foo Bar',
 				]
@@ -133,12 +138,13 @@ class ProjectLocator extends TestCase {
 
 		$locator = new Locator( 'wearerequired/traduttore-registry' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $project->get_id(), $locator->get_project()->get_id() );
 	}
 
 	public function test_find_project_by_repository_url(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Foo Bar',
 				]
@@ -149,6 +155,7 @@ class ProjectLocator extends TestCase {
 
 		$locator = new Locator( 'https://github.com/wearerequired/traduttore-registry' );
 
+		$this->assertInstanceOf( Project::class, $locator->get_project() );
 		$this->assertSame( $project->get_id(), $locator->get_project()->get_id() );
 	}
 }

--- a/tests/phpunit/tests/Repository/Bitbucket.php
+++ b/tests/phpunit/tests/Repository/Bitbucket.php
@@ -88,7 +88,7 @@ class Bitbucket extends TestCase {
 	 * @param string $url     The request URL.
 	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
+	public function mock_repository_visibility_request( bool $preempt, mixed $r, string $url ): array|false {
 		if ( BitbucketRepository::API_BASE . '/repositories/wearerequired/traduttore' === $url ) {
 			++$this->http_request_count;
 

--- a/tests/phpunit/tests/Repository/Bitbucket.php
+++ b/tests/phpunit/tests/Repository/Bitbucket.php
@@ -26,7 +26,7 @@ class Bitbucket extends TestCase {
 	 */
 	public $http_request_count = 0;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Repository/Bitbucket.php
+++ b/tests/phpunit/tests/Repository/Bitbucket.php
@@ -1,36 +1,33 @@
 <?php
 /**
  * Class BitbucketRepository
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Repository;
 
-use Required\Traduttore\Repository\Bitbucket as BitbucketRepository;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
+use Required\Traduttore\Repository\Bitbucket as BitbucketRepository;
 use Required\Traduttore\Tests\TestCase;
 
 /**
  * Test cases for \Required\Traduttore\Repository\Bitbucket.
  */
 class Bitbucket extends TestCase {
-	/** @var Project */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * Count of the number of times an HTTP request was made.
 	 *
 	 * @var int
 	 */
-	public $http_request_count = 0;
+	public int $http_request_count = 0;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -54,7 +51,7 @@ class Bitbucket extends TestCase {
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://bitbucket.org/wearerequired/traduttore/src/master/%file%#L%line%',
@@ -89,11 +86,11 @@ class Bitbucket extends TestCase {
 	 * @param false  $preempt Whether to preempt an HTTP request's return value. Default false.
 	 * @param mixed  $r       HTTP request arguments.
 	 * @param string $url     The request URL.
-	 * @return array|false Response data.
+	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( $preempt, $r, $url ) {
+	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
 		if ( BitbucketRepository::API_BASE . '/repositories/wearerequired/traduttore' === $url ) {
-			++ $this->http_request_count;
+			++$this->http_request_count;
 
 			return [
 				'response' => [
@@ -109,7 +106,7 @@ class Bitbucket extends TestCase {
 	public function test_is_public_performs_http_request_and_caches_it(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$repository = new BitbucketRepository( $this->project );
 
@@ -118,7 +115,7 @@ class Bitbucket extends TestCase {
 		$is_public_after   = $repository->is_public();
 		$visibility_after  = $repository->get_project()->get_repository_visibility();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertNull( $visibility_before );
 		$this->assertTrue( $is_public );
@@ -130,7 +127,7 @@ class Bitbucket extends TestCase {
 	public function test_is_public_performs_no_unnecessary_http_request(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$this->project->set_repository_visibility( 'private' );
 
@@ -139,7 +136,7 @@ class Bitbucket extends TestCase {
 		$visibility_before = $repository->get_project()->get_repository_visibility();
 		$is_public         = $repository->is_public();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertSame( 'private', $visibility_before );
 		$this->assertFalse( $is_public );
@@ -273,9 +270,7 @@ class Bitbucket extends TestCase {
 
 		add_filter(
 			'traduttore.git_https_credentials',
-			function() {
-				return 'foo:bar';
-			}
+			fn() => 'foo:bar'
 		);
 
 		$url = $repository->get_https_url();
@@ -291,9 +286,7 @@ class Bitbucket extends TestCase {
 
 		add_filter(
 			'traduttore.hg_https_credentials',
-			function() {
-				return 'foo:bar';
-			}
+			fn() => 'foo:bar'
 		);
 
 		$url = $repository->get_https_url();

--- a/tests/phpunit/tests/Repository/GitHub.php
+++ b/tests/phpunit/tests/Repository/GitHub.php
@@ -1,36 +1,33 @@
 <?php
 /**
  * Class GitHubRepository
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Repository;
 
-use Required\Traduttore\Repository\GitHub as GitHubRepository;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
+use Required\Traduttore\Repository\GitHub as GitHubRepository;
 use Required\Traduttore\Tests\TestCase;
 
 /**
  * Test cases for \Required\Traduttore\Repository\GitHub.
  */
 class GitHub extends TestCase {
-	/** @var Project */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * Count of the number of times an HTTP request was made.
 	 *
 	 * @var int
 	 */
-	public $http_request_count = 0;
+	public int $http_request_count = 0;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -54,7 +51,7 @@ class GitHub extends TestCase {
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -69,7 +66,7 @@ class GitHub extends TestCase {
 
 	public function test_get_name_falls_back_to_different_source_url_template(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://github.com/wearerequired/traduttore/tree/master/%file%#L%line%',
@@ -104,11 +101,11 @@ class GitHub extends TestCase {
 	 * @param false  $preempt Whether to preempt an HTTP request's return value. Default false.
 	 * @param mixed  $r       HTTP request arguments.
 	 * @param string $url     The request URL.
-	 * @return array|false Response data.
+	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( $preempt, $r, $url ) {
+	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
 		if ( GitHubRepository::API_BASE . '/repos/wearerequired/traduttore' === $url ) {
-			++ $this->http_request_count;
+			++$this->http_request_count;
 
 			return [
 				'response' => [
@@ -124,7 +121,7 @@ class GitHub extends TestCase {
 	public function test_is_public_performs_http_request_and_caches_it(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$repository = new GitHubRepository( $this->project );
 
@@ -133,7 +130,7 @@ class GitHub extends TestCase {
 		$is_public_after   = $repository->is_public();
 		$visibility_after  = $repository->get_project()->get_repository_visibility();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertNull( $visibility_before );
 		$this->assertTrue( $is_public );
@@ -145,7 +142,7 @@ class GitHub extends TestCase {
 	public function test_is_public_performs_no_unnecessary_http_request(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$this->project->set_repository_visibility( 'private' );
 
@@ -154,7 +151,7 @@ class GitHub extends TestCase {
 		$visibility_before = $repository->get_project()->get_repository_visibility();
 		$is_public         = $repository->is_public();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertSame( 'private', $visibility_before );
 		$this->assertFalse( $is_public );

--- a/tests/phpunit/tests/Repository/GitHub.php
+++ b/tests/phpunit/tests/Repository/GitHub.php
@@ -27,7 +27,7 @@ class GitHub extends TestCase {
 	 */
 	public $http_request_count = 0;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Repository/GitHub.php
+++ b/tests/phpunit/tests/Repository/GitHub.php
@@ -103,7 +103,7 @@ class GitHub extends TestCase {
 	 * @param string $url     The request URL.
 	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
+	public function mock_repository_visibility_request( bool $preempt, mixed $r, string $url ): array|false {
 		if ( GitHubRepository::API_BASE . '/repos/wearerequired/traduttore' === $url ) {
 			++$this->http_request_count;
 

--- a/tests/phpunit/tests/Repository/GitHub.php
+++ b/tests/phpunit/tests/Repository/GitHub.php
@@ -7,7 +7,6 @@
 
 namespace Required\Traduttore\Tests\Repository;
 
-use \GP_UnitTestCase;
 use Required\Traduttore\Repository\GitHub as GitHubRepository;
 use \Required\Traduttore\Project;
 use Required\Traduttore\Repository;

--- a/tests/phpunit/tests/Repository/GitLab.php
+++ b/tests/phpunit/tests/Repository/GitLab.php
@@ -1,36 +1,33 @@
 <?php
 /**
  * Class GitLabRepository
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\Repository;
 
-use Required\Traduttore\Repository\GitLab as GitLabRepository;
-use \Required\Traduttore\Project;
+use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
+use Required\Traduttore\Repository\GitLab as GitLabRepository;
 use Required\Traduttore\Tests\TestCase;
 
 /**
  * Test cases for \Required\Traduttore\Repository\GitLab.
  */
 class GitLab extends TestCase {
-	/** @var Project */
-	protected $project;
+	protected Project $project;
 
 	/**
 	 * Count of the number of times an HTTP request was made.
 	 *
 	 * @var int
 	 */
-	public $http_request_count = 0;
+	public int $http_request_count = 0;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -54,7 +51,7 @@ class GitLab extends TestCase {
 
 	public function test_get_name_falls_back_to_source_url_template(): void {
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://gitlab.com/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -103,11 +100,11 @@ class GitLab extends TestCase {
 	 * @param false  $preempt Whether to preempt an HTTP request's return value. Default false.
 	 * @param mixed  $r       HTTP request arguments.
 	 * @param string $url     The request URL.
-	 * @return array|false Response data.
+	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( $preempt, $r, $url ) {
+	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
 		if ( GitLabRepository::API_BASE . '/projects/wearerequired%2Ftraduttore' === $url ) {
-			++ $this->http_request_count;
+			++$this->http_request_count;
 
 			return [
 				'response' => [
@@ -123,7 +120,7 @@ class GitLab extends TestCase {
 	public function test_is_public_performs_http_request_and_caches_it(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$repository = new GitLabRepository( $this->project );
 
@@ -132,7 +129,7 @@ class GitLab extends TestCase {
 		$is_public_after   = $repository->is_public();
 		$visibility_after  = $repository->get_project()->get_repository_visibility();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertNull( $visibility_before );
 		$this->assertTrue( $is_public );
@@ -144,7 +141,7 @@ class GitLab extends TestCase {
 	public function test_is_public_performs_no_unnecessary_http_request(): void {
 		$this->project->set_repository_name( 'wearerequired/traduttore' );
 
-		add_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10, 3 );
 
 		$this->project->set_repository_visibility( 'private' );
 
@@ -153,7 +150,7 @@ class GitLab extends TestCase {
 		$visibility_before = $repository->get_project()->get_repository_visibility();
 		$is_public         = $repository->is_public();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_repository_visibility_request' ), 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_repository_visibility_request' ], 10 );
 
 		$this->assertSame( 'private', $visibility_before );
 		$this->assertFalse( $is_public );

--- a/tests/phpunit/tests/Repository/GitLab.php
+++ b/tests/phpunit/tests/Repository/GitLab.php
@@ -7,7 +7,6 @@
 
 namespace Required\Traduttore\Tests\Repository;
 
-use \GP_UnitTestCase;
 use Required\Traduttore\Repository\GitLab as GitLabRepository;
 use \Required\Traduttore\Project;
 use Required\Traduttore\Repository;

--- a/tests/phpunit/tests/Repository/GitLab.php
+++ b/tests/phpunit/tests/Repository/GitLab.php
@@ -27,7 +27,7 @@ class GitLab extends TestCase {
 	 */
 	public $http_request_count = 0;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Repository/GitLab.php
+++ b/tests/phpunit/tests/Repository/GitLab.php
@@ -102,7 +102,7 @@ class GitLab extends TestCase {
 	 * @param string $url     The request URL.
 	 * @return array{response: array{ code: int }, body: string}|false Response data.
 	 */
-	public function mock_repository_visibility_request( false $preempt, mixed $r, string $url ): array|false {
+	public function mock_repository_visibility_request( bool $preempt, mixed $r, string $url ): array|false {
 		if ( GitLabRepository::API_BASE . '/projects/wearerequired%2Ftraduttore' === $url ) {
 			++$this->http_request_count;
 

--- a/tests/phpunit/tests/RepositoryFactory.php
+++ b/tests/phpunit/tests/RepositoryFactory.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Class RepositoryFactory
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use Required\Traduttore\Repository\{Bitbucket, GitHub, GitLab};
-use \Required\Traduttore\Project;
-use \Required\Traduttore\RepositoryFactory as Factory;
+use Required\Traduttore\Repository\Bitbucket;
+use Required\Traduttore\Repository\GitHub;
+use Required\Traduttore\Repository\GitLab;
+use Required\Traduttore\Project;
+use Required\Traduttore\RepositoryFactory as Factory;
 
 /**
  * Test cases for \Required\Traduttore\RepositoryFactory.
@@ -18,7 +18,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_unknown_repository(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -31,7 +31,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_unknown_repository_by_type(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -46,7 +46,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_bitbucket_repository_by_type(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -61,7 +61,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_bitbucket_repository_by_url(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -76,7 +76,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_bitbucket_repository_by_source_url_template(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://bitbucket.org/wearerequired/traduttore/src/master/%file%#L%line%',
@@ -90,7 +90,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_github_repository_by_type(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -105,7 +105,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_github_repository_by_url(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -120,7 +120,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_github_repository_by_source_url_template(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -134,7 +134,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_gitlab_repository_by_type(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name' => 'Project',
 				]
@@ -149,7 +149,7 @@ class RepositoryFactory extends TestCase {
 	public function test_get_gitlab_repository_by_source_url_template(): void {
 		$factory = new Factory();
 		$project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Project',
 					'source_url_template' => 'https://gitlab.com/wearerequired/traduttore/blob/master/%file%#L%line%',

--- a/tests/phpunit/tests/RestrictedSiteAccess.php
+++ b/tests/phpunit/tests/RestrictedSiteAccess.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * RestrictedSiteAccess class.
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;

--- a/tests/phpunit/tests/Runner.php
+++ b/tests/phpunit/tests/Runner.php
@@ -31,7 +31,7 @@ class Runner extends TestCase {
 	 */
 	protected $loader;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
@@ -63,7 +63,7 @@ class Runner extends TestCase {
 
 		$this->assertFileExists( $this->loader->get_local_path() . '/foo.txt' );
 		$this->assertTrue( $this->runner->delete_local_repository() );
-		$this->assertFileNotExists( $this->loader->get_local_path() . '/foo.txt' );
+		$this->assertFileDoesNotExist( $this->loader->get_local_path() . '/foo.txt' );
 	}
 
 	public function test_delete_local_repository_without_filesystem(): void {
@@ -138,7 +138,7 @@ class Runner extends TestCase {
 
 		$loader = $this->createMock( Loader::class );
 		$loader->expects( $this->once() )->method( 'get_local_path' )->willReturn( $test_path );
-		$loader->expects( $this->never() )->method( 'download' )->willReturn( false );
+		$loader->expects( $this->never() )->method( 'download' )->willReturn( null );
 
 		mkdir( $loader->get_local_path() );
 

--- a/tests/phpunit/tests/Runner.php
+++ b/tests/phpunit/tests/Runner.php
@@ -14,20 +14,11 @@ use Required\Traduttore\Updater;
  * Test cases for \Required\Traduttore\Runner.
  */
 class Runner extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\Project
-	 */
-	protected $project;
+	protected Project $project;
 
-	/**
-	 * @var \Required\Traduttore\Tests\R
-	 */
-	protected $runner;
+	protected R $runner;
 
-	/**
-	 * @var \Required\Traduttore\Loader
-	 */
-	protected $loader;
+	protected Loader $loader;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/Runner.php
+++ b/tests/phpunit/tests/Runner.php
@@ -1,28 +1,26 @@
 <?php
 /**
  * Class Runner
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use \Required\Traduttore\Project;
-use \Required\Traduttore\Updater;
-use \Required\Traduttore\Runner as R;
-use \Required\Traduttore\Loader\Git as Loader;
+use Required\Traduttore\Loader\Git as Loader;
+use Required\Traduttore\Project;
+use Required\Traduttore\Runner as R;
+use Required\Traduttore\Updater;
 
 /**
  * Test cases for \Required\Traduttore\Runner.
  */
 class Runner extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Tests\Project
 	 */
 	protected $project;
 
 	/**
-	 * @var R
+	 * @var \Required\Traduttore\Tests\R
 	 */
 	protected $runner;
 
@@ -35,7 +33,7 @@ class Runner extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'slug'                => 'sample-project',

--- a/tests/phpunit/tests/TestCase.php
+++ b/tests/phpunit/tests/TestCase.php
@@ -28,11 +28,11 @@ class TestCase extends GP_UnitTestCase {
 		}
 
 		$this->assertInstanceOf( 'WP_Error', $response );
-		$this->assertEquals( $code, $response->get_error_code() );
+		$this->assertSame( $code, $response->get_error_code() );
 		if ( null !== $status ) {
 			$data = $response->get_error_data();
 			$this->assertArrayHasKey( 'status', $data );
-			$this->assertEquals( $status, $data['status'] );
+			$this->assertSame( $status, $data['status'] );
 		}
 	}
 }

--- a/tests/phpunit/tests/TestCase.php
+++ b/tests/phpunit/tests/TestCase.php
@@ -1,14 +1,12 @@
 <?php
 /**
  * Class TestCase
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
+use GP_UnitTest_Factory;
 use GP_UnitTestCase;
-use WP_Error;
 use WP_REST_Response;
 
 /**
@@ -16,13 +14,22 @@ use WP_REST_Response;
  */
 class TestCase extends GP_UnitTestCase {
 	/**
-	 * @see WP_Test_REST_TestCase
+	 * Fetches the factory object for generating WordPress fixtures.
 	 *
-	 * @param mixed                     $code
-	 * @param WP_REST_Response|WP_Error $response
-	 * @param mixed                     $status
+	 * @return \GP_UnitTest_Factory The fixture factory.
 	 */
-	protected function assertErrorResponse( $code, $response, $status = null ): void {
+	protected static function factory(): GP_UnitTest_Factory {
+		static $factory = null;
+		if ( ! $factory ) {
+			$factory = new GP_UnitTest_Factory();
+		}
+		return $factory;
+	}
+
+	/**
+	 * @see WP_Test_REST_TestCase
+	 */
+	protected function assertErrorResponse( mixed $code, WP_REST_Response|WP_Error $response, mixed $status = null ): void {
 		if ( $response instanceof WP_REST_Response ) {
 			$response = $response->as_error();
 		}
@@ -31,6 +38,7 @@ class TestCase extends GP_UnitTestCase {
 		$this->assertSame( $code, $response->get_error_code() );
 		if ( null !== $status ) {
 			$data = $response->get_error_data();
+			$this->assertIsArray( $data );
 			$this->assertArrayHasKey( 'status', $data );
 			$this->assertSame( $status, $data['status'] );
 		}

--- a/tests/phpunit/tests/TestCase.php
+++ b/tests/phpunit/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace Required\Traduttore\Tests;
 
 use GP_UnitTest_Factory;
 use GP_UnitTestCase;
+use WP_Error;
 use WP_REST_Response;
 
 /**

--- a/tests/phpunit/tests/TranslationApiRoute.php
+++ b/tests/phpunit/tests/TranslationApiRoute.php
@@ -29,7 +29,7 @@ class TranslationApiRoute extends GP_UnitTestCase_Route {
 	 */
 	protected $locale;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->locale = $this->factory->locale->create(
@@ -51,7 +51,7 @@ class TranslationApiRoute extends GP_UnitTestCase_Route {
 		);
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		/* @var \WP_Filesystem_Base $wp_filesystem */
 		global $wp_filesystem;
 
@@ -127,16 +127,16 @@ class TranslationApiRoute extends GP_UnitTestCase_Route {
 		$response = $this->get_route_callback( 'foo-project' );
 
 		$this->assertCount( 1, $response['translations'] );
-		$this->assertArraySubset(
-			[
-				'language'     => 'de_DE',
-				'version'      => '1.0',
-				'english_name' => 'German',
-				'native_name'  => 'Deutsch',
-				'package'      => $provider->get_zip_url(),
-			],
-			$response['translations'][0]
-		);
+		$this->assertArrayHasKey( 'language', $response['translations'][0] );
+		$this->assertSame( 'de_DE', $response['translations'][0]['language'] );
+		$this->assertArrayHasKey( 'version', $response['translations'][0] );
+		$this->assertSame( '1.0', $response['translations'][0]['version'] );
+		$this->assertArrayHasKey( 'english_name', $response['translations'][0] );
+		$this->assertSame( 'German', $response['translations'][0]['english_name'] );
+		$this->assertArrayHasKey( 'native_name', $response['translations'][0] );
+		$this->assertSame( 'Deutsch', $response['translations'][0]['native_name'] );
+		$this->assertArrayHasKey( 'package', $response['translations'][0] );
+		$this->assertSame( $provider->get_zip_url(), $response['translations'][0]['package'] );
 	}
 
 	public function test_missing_build_time(): void {
@@ -182,15 +182,16 @@ class TranslationApiRoute extends GP_UnitTestCase_Route {
 		$response = $this->get_route_callback( 'foo-project' );
 
 		$this->assertCount( 1, $response['translations'] );
-		$this->assertArraySubset(
-			[
-				'language'     => 'de_DE',
-				'version'      => '1.2.3',
-				'english_name' => 'German',
-				'native_name'  => 'Deutsch',
-				'package'      => $provider->get_zip_url(),
-			],
-			$response['translations'][0]
-		);
+		$this->assertCount( 1, $response['translations'] );
+		$this->assertArrayHasKey( 'language', $response['translations'][0] );
+		$this->assertSame( 'de_DE', $response['translations'][0]['language'] );
+		$this->assertArrayHasKey( 'version', $response['translations'][0] );
+		$this->assertSame( '1.2.3', $response['translations'][0]['version'] );
+		$this->assertArrayHasKey( 'english_name', $response['translations'][0] );
+		$this->assertSame( 'German', $response['translations'][0]['english_name'] );
+		$this->assertArrayHasKey( 'native_name', $response['translations'][0] );
+		$this->assertSame( 'Deutsch', $response['translations'][0]['native_name'] );
+		$this->assertArrayHasKey( 'package', $response['translations'][0] );
+		$this->assertSame( $provider->get_zip_url(), $response['translations'][0]['package'] );
 	}
 }

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -14,15 +14,9 @@ use Required\Traduttore\Updater as U;
  * Test cases for \Required\Traduttore\Updater.
  */
 class Updater extends TestCase {
-	/**
-	 * @var \Required\Traduttore\Tests\Project
-	 */
-	protected $project;
+	protected Project $project;
 
-	/**
-	 * @var \Required\Traduttore\Tests\U
-	 */
-	protected $updater;
+	protected U $updater;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -26,7 +26,7 @@ class Updater extends TestCase {
 	 */
 	protected $updater;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -1,28 +1,26 @@
 <?php
 /**
  * Class Updater
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
-use \GP;
-use \Required\Traduttore\Configuration;
-use \Required\Traduttore\Project;
-use \Required\Traduttore\Updater as U;
+use GP;
+use Required\Traduttore\Configuration;
+use Required\Traduttore\Project;
+use Required\Traduttore\Updater as U;
 
 /**
  * Test cases for \Required\Traduttore\Updater.
  */
 class Updater extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Tests\Project
 	 */
 	protected $project;
 
 	/**
-	 * @var U
+	 * @var \Required\Traduttore\Tests\U
 	 */
 	protected $updater;
 
@@ -30,7 +28,7 @@ class Updater extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'slug'                => 'sample-project',
@@ -43,7 +41,7 @@ class Updater extends TestCase {
 	}
 
 	public function test_update_without_config(): void {
-		$config = new Configuration( dirname( __DIR__ ) . '/data/example-no-config' );
+		$config = new Configuration( \dirname( __DIR__ ) . '/data/example-no-config' );
 
 		$result = $this->updater->update( $config );
 
@@ -57,7 +55,7 @@ class Updater extends TestCase {
 	}
 
 	public function test_update_with_composer_config(): void {
-		$config = new Configuration( dirname( __DIR__ ) . '/data/example-with-composer' );
+		$config = new Configuration( \dirname( __DIR__ ) . '/data/example-with-composer' );
 
 		$result = $this->updater->update( $config );
 
@@ -71,7 +69,7 @@ class Updater extends TestCase {
 	}
 
 	public function test_update_with_config_file(): void {
-		$config = new Configuration( dirname( __DIR__ ) . '/data/example-with-config' );
+		$config = new Configuration( \dirname( __DIR__ ) . '/data/example-with-config' );
 
 		$result = $this->updater->update( $config );
 
@@ -109,7 +107,7 @@ class Updater extends TestCase {
 
 		foreach ( $crons as $timestamp => $cron ) {
 			if ( isset( $cron['traduttore.update'][ $key ] ) ) {
-				$scheduled_count ++;
+				$scheduled_count++;
 			}
 		}
 
@@ -121,7 +119,7 @@ class Updater extends TestCase {
 
 		foreach ( $crons as $timestamp => $cron ) {
 			if ( isset( $cron['traduttore.update'][ $key ] ) ) {
-				$scheduled_count ++;
+				$scheduled_count++;
 			}
 		}
 
@@ -135,7 +133,7 @@ class Updater extends TestCase {
 
 		foreach ( $crons as $timestamp => $cron ) {
 			if ( isset( $cron['traduttore.update'][ $key ] ) ) {
-				$scheduled_count ++;
+				$scheduled_count++;
 			}
 		}
 

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Class Bitbucket
- *
- * @package Traduttore\Tests\WebhookHandler
+ * Class Bitbucket\WebhookHandler
  */
 
 namespace Required\Traduttore\Tests\WebhookHandler;
@@ -10,22 +8,19 @@ namespace Required\Traduttore\Tests\WebhookHandler;
 use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Tests\TestCase;
-use \WP_REST_Request;
+use WP_REST_Request;
 
 /**
  * Test cases for \Required\Traduttore\WebhookHandler\Bitbucket.
  */
 class Bitbucket extends TestCase {
-	/**
-	 * @var Project
-	 */
-	protected $project;
+	protected Project $project;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'source_url_template' => 'https://bitbucket.org/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -52,9 +47,9 @@ class Bitbucket extends TestCase {
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_body_params( [] );
-		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'foo' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'foo' );
 		$request->add_header( 'x-event-key', 'repo:push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
@@ -100,9 +95,9 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 404, $response );
@@ -125,9 +120,9 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -160,9 +155,9 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -21,7 +21,7 @@ class Bitbucket extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
@@ -52,7 +52,7 @@ class Bitbucket extends TestCase {
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_body_params( [] );
-		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'foo' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'foo' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -100,7 +100,7 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -125,12 +125,12 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_BITBUCKET, $this->project->get_repository_type() );
@@ -160,12 +160,12 @@ class Bitbucket extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_HG, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_BITBUCKET, $this->project->get_repository_type() );

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -46,8 +46,9 @@ class Bitbucket extends TestCase {
 
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params( [] );
-		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'foo' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( [] ) );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'foo' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -57,20 +58,23 @@ class Bitbucket extends TestCase {
 
 	public function test_missing_signature_is_valid(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'links'      => [
-						'html' => [
-							'href' => 'https://bitbucket.org/wearerequired/not-traduttore',
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'links'      => [
+							'html' => [
+								'href' => 'https://bitbucket.org/wearerequired/not-traduttore',
+							],
 						],
+						'full_name'  => 'wearerequired/not-traduttore',
+						'scm'        => 'git',
+						'is_private' => false,
 					],
-					'full_name'  => 'wearerequired/not-traduttore',
-					'scm'        => 'git',
-					'is_private' => false,
-				],
-			]
+				]
+			)
 		);
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$response = rest_get_server()->dispatch( $request );
@@ -80,22 +84,25 @@ class Bitbucket extends TestCase {
 
 	public function test_invalid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'links'      => [
-						'html' => [
-							'href' => 'https://bitbucket.org/wearerequired/not-traduttore',
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'links'      => [
+							'html' => [
+								'href' => 'https://bitbucket.org/wearerequired/not-traduttore',
+							],
 						],
+						'full_name'  => 'wearerequired/not-traduttore',
+						'scm'        => 'git',
+						'is_private' => false,
 					],
-					'full_name'  => 'wearerequired/not-traduttore',
-					'scm'        => 'git',
-					'is_private' => false,
-				],
-			]
+				]
+			)
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -105,22 +112,25 @@ class Bitbucket extends TestCase {
 
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'links'      => [
-						'html' => [
-							'href' => 'https://bitbucket.org/wearerequired/traduttore',
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'links'      => [
+							'html' => [
+								'href' => 'https://bitbucket.org/wearerequired/traduttore',
+							],
 						],
+						'full_name'  => 'wearerequired/traduttore',
+						'scm'        => 'git',
+						'is_private' => false,
 					],
-					'full_name'  => 'wearerequired/traduttore',
-					'scm'        => 'git',
-					'is_private' => false,
-				],
-			]
+				]
+			)
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -140,22 +150,25 @@ class Bitbucket extends TestCase {
 		$this->project->set_repository_vcs_type( Repository::VCS_TYPE_HG );
 
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'links'      => [
-						'html' => [
-							'href' => 'https://bitbucket.org/wearerequired/traduttore',
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'links'      => [
+							'html' => [
+								'href' => 'https://bitbucket.org/wearerequired/traduttore',
+							],
 						],
+						'full_name'  => 'wearerequired/traduttore',
+						'scm'        => 'git',
+						'is_private' => false,
 					],
-					'full_name'  => 'wearerequired/traduttore',
-					'scm'        => 'git',
-					'is_private' => false,
-				],
-			]
+				]
+			)
 		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', (string) wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-event-key', 'repo:push' );
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/WebhookHandler/GitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/GitHub.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Class GitHub
- *
- * @package Traduttore\Tests\WebhookHandler
+ * Class GitHub\WebhookHandler
  */
 
 namespace Required\Traduttore\Tests\WebhookHandler;
@@ -10,14 +8,14 @@ namespace Required\Traduttore\Tests\WebhookHandler;
 use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Tests\TestCase;
-use \WP_REST_Request;
+use WP_REST_Request;
 
 /**
  * Test cases for \Required\Traduttore\WebhookHandler\GitHub.
  */
 class GitHub extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Project
 	 */
 	protected $project;
 
@@ -25,7 +23,7 @@ class GitHub extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -70,9 +68,9 @@ class GitHub extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->add_header( 'Content-Type', 'application/json' );
 		$request->set_body( (string) wp_json_encode( [] ) );
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
@@ -92,9 +90,9 @@ class GitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -120,9 +118,9 @@ class GitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 404, $response );
@@ -138,9 +136,9 @@ class GitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 400, $response );
@@ -150,7 +148,7 @@ class GitHub extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->add_header( 'Content-Type', 'application/json' );
 		$request->set_body(
-		  (string) wp_json_encode(
+			(string) wp_json_encode(
 				[
 					'ref'        => 'refs/heads/master',
 					'repository' => [
@@ -165,9 +163,9 @@ class GitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -185,25 +183,27 @@ class GitHub extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
 		$data = [
-			'payload' => json_encode( [
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'full_name'      => 'wearerequired/traduttore',
-					'default_branch' => 'master',
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-					'url'            => 'https://github.com/wearerequired/traduttore',
-					'private'        => false,
-				],
-			] )
+			'payload' => json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'full_name'      => 'wearerequired/traduttore',
+						'default_branch' => 'master',
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+						'url'            => 'https://github.com/wearerequired/traduttore',
+						'private'        => false,
+					],
+				]
+			),
 		];
 		$request->set_body_params( $data );
 		$request->set_body( http_build_query( $data ) );
 
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -240,9 +240,9 @@ class GitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), $secret );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/phpunit/tests/WebhookHandler/GitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/GitHub.php
@@ -141,7 +141,7 @@ class GitHub extends TestCase {
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 400, $response );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
 	}
 
 	public function test_valid_project(): void {

--- a/tests/phpunit/tests/WebhookHandler/GitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/GitHub.php
@@ -21,7 +21,7 @@ class GitHub extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
@@ -54,7 +54,7 @@ class GitHub extends TestCase {
 		$request->add_header( 'x-github-event', 'ping' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 	}
 
@@ -69,7 +69,7 @@ class GitHub extends TestCase {
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_body_params( [] );
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -88,12 +88,12 @@ class GitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
 	}
 
@@ -113,7 +113,7 @@ class GitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -128,7 +128,7 @@ class GitHub extends TestCase {
 				'ref' => 'refs/heads/master',
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -152,12 +152,12 @@ class GitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITHUB, $this->project->get_repository_type() );
@@ -187,12 +187,12 @@ class GitHub extends TestCase {
 				] )
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITHUB, $this->project->get_repository_type() );
@@ -223,12 +223,12 @@ class GitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), $secret );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITHUB, $this->project->get_repository_type() );

--- a/tests/phpunit/tests/WebhookHandler/GitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/GitHub.php
@@ -68,8 +68,9 @@ class GitHub extends TestCase {
 
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params( [] );
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'foo' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( [] ) );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -79,16 +80,19 @@ class GitHub extends TestCase {
 
 	public function test_invalid_branch(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'default_branch' => 'develop',
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'default_branch' => 'develop',
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -99,21 +103,24 @@ class GitHub extends TestCase {
 
 	public function test_invalid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'default_branch' => 'master',
-					'full_name'      => 'wearerequired/not-traduttore',
-					'html_url'       => 'https://github.com/wearerequired/not-traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/not-traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/not-traduttore.git',
-					'url'            => 'https://github.com/wearerequired/not-traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'default_branch' => 'master',
+						'full_name'      => 'wearerequired/not-traduttore',
+						'html_url'       => 'https://github.com/wearerequired/not-traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/not-traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/not-traduttore.git',
+						'url'            => 'https://github.com/wearerequired/not-traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -123,12 +130,15 @@ class GitHub extends TestCase {
 
 	public function test_invalid_request(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref' => 'refs/heads/master',
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref' => 'refs/heads/master',
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -138,21 +148,24 @@ class GitHub extends TestCase {
 
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'full_name'      => 'wearerequired/traduttore',
-					'default_branch' => 'master',
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-					'url'            => 'https://github.com/wearerequired/traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+		  (string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'full_name'      => 'wearerequired/traduttore',
+						'default_branch' => 'master',
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+						'url'            => 'https://github.com/wearerequired/traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -171,23 +184,24 @@ class GitHub extends TestCase {
 	public function test_valid_project_with_x_www_form_urlencoded_content_type(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
-		$request->set_body_params(
-			[
-				'payload' => json_encode( [
-					'ref'        => 'refs/heads/master',
-					'repository' => [
-						'full_name'      => 'wearerequired/traduttore',
-						'default_branch' => 'master',
-						'html_url'       => 'https://github.com/wearerequired/traduttore',
-						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-						'url'            => 'https://github.com/wearerequired/traduttore',
-						'private'        => false,
-					],
-				] )
-			]
-		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$data = [
+			'payload' => json_encode( [
+				'ref'        => 'refs/heads/master',
+				'repository' => [
+					'full_name'      => 'wearerequired/traduttore',
+					'default_branch' => 'master',
+					'html_url'       => 'https://github.com/wearerequired/traduttore',
+					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+					'url'            => 'https://github.com/wearerequired/traduttore',
+					'private'        => false,
+				],
+			] )
+		];
+		$request->set_body_params( $data );
+		$request->set_body( http_build_query( $data ) );
+
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -209,21 +223,24 @@ class GitHub extends TestCase {
 		$this->project->set_repository_webhook_secret( $secret );
 
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'full_name'      => 'wearerequired/traduttore',
-					'default_branch' => 'master',
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-					'url'            => 'https://github.com/wearerequired/traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'full_name'      => 'wearerequired/traduttore',
+						'default_branch' => 'master',
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+						'url'            => 'https://github.com/wearerequired/traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), $secret );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/WebhookHandler/GitLab.php
+++ b/tests/phpunit/tests/WebhookHandler/GitLab.php
@@ -21,7 +21,7 @@ class GitLab extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
@@ -82,7 +82,7 @@ class GitLab extends TestCase {
 		$request->add_header( 'x-gitlab-token', 'traduttore-test' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
 	}
 
@@ -127,7 +127,7 @@ class GitLab extends TestCase {
 		$request->add_header( 'x-gitlab-token', 'traduttore-test' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITLAB, $this->project->get_repository_type() );
@@ -161,7 +161,7 @@ class GitLab extends TestCase {
 		$request->add_header( 'x-gitlab-token', $secret );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITLAB, $this->project->get_repository_type() );

--- a/tests/phpunit/tests/WebhookHandler/GitLab.php
+++ b/tests/phpunit/tests/WebhookHandler/GitLab.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Class GitLab
- *
- * @package Traduttore\Tests\WebhookHandler
+ * Class GitLab\WebhookHandler
  */
 
 namespace Required\Traduttore\Tests\WebhookHandler;
@@ -10,14 +8,14 @@ namespace Required\Traduttore\Tests\WebhookHandler;
 use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Tests\TestCase;
-use \WP_REST_Request;
+use WP_REST_Request;
 
 /**
  * Test cases for \Required\Traduttore\WebhookHandler\GitLab.
  */
 class GitLab extends TestCase {
 	/**
-	 * @var Project
+	 * @var \Required\Traduttore\Project
 	 */
 	protected $project;
 
@@ -25,7 +23,7 @@ class GitLab extends TestCase {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'source_url_template' => 'https://gitlab.com/wearerequired/traduttore/blob/master/%file%#L%line%',

--- a/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
@@ -68,8 +68,9 @@ class LegacyGitHub extends TestCase {
 
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
-		$request->set_body_params( [] );
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'foo' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( [] ) );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -79,16 +80,19 @@ class LegacyGitHub extends TestCase {
 
 	public function test_invalid_branch(): void {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'default_branch' => 'develop',
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'default_branch' => 'develop',
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -99,21 +103,24 @@ class LegacyGitHub extends TestCase {
 
 	public function test_invalid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'default_branch' => 'master',
-					'full_name'      => 'wearerequired/not-traduttore',
-					'html_url'       => 'https://github.com/wearerequired/not-traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/not-traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/not-traduttore.git',
-					'url'            => 'https://github.com/wearerequired/not-traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'default_branch' => 'master',
+						'full_name'      => 'wearerequired/not-traduttore',
+						'html_url'       => 'https://github.com/wearerequired/not-traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/not-traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/not-traduttore.git',
+						'url'            => 'https://github.com/wearerequired/not-traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -123,21 +130,24 @@ class LegacyGitHub extends TestCase {
 
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'full_name'      => 'wearerequired/traduttore',
-					'default_branch' => 'master',
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-					'url'            => 'https://github.com/wearerequired/traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'full_name'      => 'wearerequired/traduttore',
+						'default_branch' => 'master',
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+						'url'            => 'https://github.com/wearerequired/traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -159,21 +169,24 @@ class LegacyGitHub extends TestCase {
 		$this->project->set_repository_webhook_secret( $secret );
 
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
-		$request->set_body_params(
-			[
-				'ref'        => 'refs/heads/master',
-				'repository' => [
-					'full_name'      => 'wearerequired/traduttore',
-					'default_branch' => 'master',
-					'html_url'       => 'https://github.com/wearerequired/traduttore',
-					'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
-					'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
-					'url'            => 'https://github.com/wearerequired/traduttore',
-					'private'        => false,
-				],
-			]
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'full_name'      => 'wearerequired/traduttore',
+						'default_branch' => 'master',
+						'html_url'       => 'https://github.com/wearerequired/traduttore',
+						'ssh_url'        => 'git@github.com:wearerequired/traduttore.git',
+						'clone_url'      => 'https://github.com/wearerequired/traduttore.git',
+						'url'            => 'https://github.com/wearerequired/traduttore',
+						'private'        => false,
+					],
+				]
+			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), $secret );
+		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
@@ -21,7 +21,7 @@ class LegacyGitHub extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
@@ -54,7 +54,7 @@ class LegacyGitHub extends TestCase {
 		$request->add_header( 'x-github-event', 'ping' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 	}
 
@@ -69,7 +69,7 @@ class LegacyGitHub extends TestCase {
 	public function test_invalid_signature(): void {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
 		$request->set_body_params( [] );
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -88,12 +88,12 @@ class LegacyGitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
 	}
 
@@ -113,7 +113,7 @@ class LegacyGitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
@@ -137,12 +137,12 @@ class LegacyGitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITHUB, $this->project->get_repository_type() );
@@ -173,12 +173,12 @@ class LegacyGitHub extends TestCase {
 				],
 			]
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
+		$signature = 'sha1=' . hash_hmac( 'sha1', wp_json_encode( $request->get_params() ), $secret );
 		$request->add_header( 'x-github-event', 'push' );
 		$request->add_header( 'x-hub-signature', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( [ 'result' => 'OK' ], $response->get_data() );
 		$this->assertSame( Repository::VCS_TYPE_GIT, $this->project->get_repository_vcs_type() );
 		$this->assertSame( Repository::TYPE_GITHUB, $this->project->get_repository_type() );

--- a/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Class LegacyGitHub
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests\WebhookHandler;
@@ -10,22 +8,19 @@ namespace Required\Traduttore\Tests\WebhookHandler;
 use Required\Traduttore\Project;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Tests\TestCase;
-use \WP_REST_Request;
+use WP_REST_Request;
 
 /**
  * Test cases for \Required\Traduttore\WebhookHandler\GitHub.
  */
 class LegacyGitHub extends TestCase {
-	/**
-	 * @var Project
-	 */
-	protected $project;
+	protected Project $project;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->project = new Project(
-			$this->factory->project->create(
+			$this->factory()->project->create(
 				[
 					'name'                => 'Sample Project',
 					'source_url_template' => 'https://github.com/wearerequired/traduttore/blob/master/%file%#L%line%',
@@ -70,9 +65,9 @@ class LegacyGitHub extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/github-webhook/v1/push-event' );
 		$request->add_header( 'Content-Type', 'application/json' );
 		$request->set_body( (string) wp_json_encode( [] ) );
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'foo' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'foo' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
@@ -92,9 +87,9 @@ class LegacyGitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -120,9 +115,9 @@ class LegacyGitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 404, $response );
@@ -147,9 +142,9 @@ class LegacyGitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), 'traduttore-test' );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -186,9 +181,9 @@ class LegacyGitHub extends TestCase {
 				]
 			)
 		);
-		$signature = 'sha1=' . hash_hmac( 'sha1', $request->get_body(), $secret );
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), $secret );
 		$request->add_header( 'x-github-event', 'push' );
-		$request->add_header( 'x-hub-signature', $signature );
+		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/phpunit/tests/ZipProvider.php
+++ b/tests/phpunit/tests/ZipProvider.php
@@ -1,17 +1,14 @@
 <?php
 /**
  * Class ZipProvider
- *
- * @package Traduttore\Tests
  */
 
 namespace Required\Traduttore\Tests;
 
 use DateTime;
 use GP;
-use GP_Translation_Set;
 use Required\Traduttore\ProjectLocator;
-use \Required\Traduttore\ZipProvider as Provider;
+use Required\Traduttore\ZipProvider as Provider;
 use Translations;
 use ZipArchive;
 
@@ -25,12 +22,12 @@ class ZipProvider extends TestCase {
 	protected $locale;
 
 	/**
-	 * @var GP_Translation_Set
+	 * @var \GP_Translation_Set
 	 */
 	protected $translation_set;
 
 	/**
-	 * @var GP_Translation_Set
+	 * @var \GP_Translation_Set
 	 */
 	protected $sub_translation_set;
 
@@ -42,14 +39,14 @@ class ZipProvider extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->locale = $this->factory->locale->create(
+		$this->locale = $this->factory()->locale->create(
 			[
 				'slug'      => 'de',
 				'wp_locale' => 'de_DE',
 			]
 		);
 
-		$this->translation_set = $this->factory->translation_set->create_with_project(
+		$this->translation_set = $this->factory()->translation_set->create_with_project(
 			[
 				'locale' => $this->locale->slug,
 			],
@@ -58,7 +55,7 @@ class ZipProvider extends TestCase {
 			]
 		);
 
-		$this->sub_translation_set = $this->factory->translation_set->create_with_project(
+		$this->sub_translation_set = $this->factory()->translation_set->create_with_project(
 			[
 				'locale' => $this->locale->slug,
 			],
@@ -68,7 +65,11 @@ class ZipProvider extends TestCase {
 			]
 		);
 
-		$this->project = new \Required\Traduttore\Project( GP::$project->get( $this->translation_set->project_id ) );
+		$gp_project = GP::$project->get( $this->translation_set->project_id );
+
+		$this->assertNotFalse( $gp_project );
+
+		$this->project = new \Required\Traduttore\Project( $gp_project );
 	}
 
 	public function tearDown(): void {
@@ -145,9 +146,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_generate_zip_file(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -165,9 +166,9 @@ class ZipProvider extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_generate_zip_file_missing_wp_filesystem(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -185,9 +186,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_replaces_existing_zip_file(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -219,9 +220,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_get_last_build_time_after_zip_generation(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -237,9 +238,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_remove_zip_file(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -255,9 +256,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_remove_zip_file_resets_build_time(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -284,9 +285,9 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_remove_zip_file_no_filesystem(): void {
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
-		$this->factory->translation->create(
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -308,10 +309,13 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_use_text_domain_for_translation_files(): void {
-		$project  = ( new ProjectLocator( $this->translation_set->project_id ) )->get_project();
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$project = ( new ProjectLocator( $this->translation_set->project_id ) )->get_project();
 
-		$this->factory->translation->create(
+		$this->assertInstanceOf( \Required\Traduttore\Project::class, $project );
+
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+
+		$this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -325,9 +329,9 @@ class ZipProvider extends TestCase {
 		$result   = $provider->generate_zip_file();
 
 		$expected_files = [
-		  'foo-bar-baz-de_DE.po',
-		  'foo-bar-baz-de_DE.mo',
-		  'foo-bar-baz-de_DE.l10n.php'
+			'foo-bar-baz-de_DE.po',
+			'foo-bar-baz-de_DE.mo',
+			'foo-bar-baz-de_DE.l10n.php',
 		];
 		$actual_files   = [];
 
@@ -335,10 +339,13 @@ class ZipProvider extends TestCase {
 
 		$zip->open( $provider->get_zip_path() );
 
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
-		for ( $i = 0; $i < $zip->numFiles; $i ++ ) {
-			$stat           = $zip->statIndex( $i );
-			$actual_files[] = $stat['name'];
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+			$stat = $zip->statIndex( $i );
+
+			if ( $stat ) {
+				$actual_files[] = $stat['name'];
+			}
 		}
 
 		$zip->close();
@@ -370,9 +377,9 @@ class ZipProvider extends TestCase {
 
 		$crons = _get_cron_array();
 		$key   = md5( serialize( [ $this->translation_set->id ] ) );
-		foreach ( $crons as $timestamp => $cron ) {
+		foreach ( $crons as $cron ) {
 			if ( isset( $cron['traduttore.generate_zip'][ $key ] ) ) {
-				$actual_count ++;
+				$actual_count++;
 			}
 		}
 
@@ -380,11 +387,11 @@ class ZipProvider extends TestCase {
 	}
 
 	public function test_does_not_schedule_generation_after_saving_translation_for_inactive_project(): void {
-		$original           = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original           = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 		$translation_set_id = (int) $this->translation_set->id;
 
 		/** @var \GP_Translation $translation */
-		$translation = $this->factory->translation->create(
+		$translation = $this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -408,11 +415,11 @@ class ZipProvider extends TestCase {
 	public function test_schedules_generation_after_saving_translation(): void {
 		$this->project->get_project()->save( [ 'active' => 1 ] );
 
-		$original           = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original           = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 		$translation_set_id = (int) $this->translation_set->id;
 
 		/** @var \GP_Translation $translation */
-		$translation = $this->factory->translation->create(
+		$translation = $this->factory()->translation->create(
 			[
 				'original_id'        => $original->id,
 				'translation_set_id' => $this->translation_set->id,
@@ -435,7 +442,7 @@ class ZipProvider extends TestCase {
 
 	public function test_does_not_schedule_generation_after_importing_originals_for_inactive_project(): void {
 		/** @var \GP_Original $original */
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
 		$before = wp_next_scheduled( 'traduttore.generate_zip', [ $this->translation_set->id ] );
 
@@ -453,7 +460,7 @@ class ZipProvider extends TestCase {
 		$this->project->get_project()->save( [ 'active' => 1 ] );
 
 		/** @var \GP_Original $original */
-		$original = $this->factory->original->create( [ 'project_id' => $this->translation_set->project_id ] );
+		$original = $this->factory()->original->create( [ 'project_id' => $this->translation_set->project_id ] );
 
 		$before = wp_next_scheduled( 'traduttore.generate_zip', [ $this->translation_set->id ] );
 

--- a/tests/phpunit/tests/ZipProvider.php
+++ b/tests/phpunit/tests/ZipProvider.php
@@ -39,7 +39,7 @@ class ZipProvider extends TestCase {
 	 */
 	protected $project;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->locale = $this->factory->locale->create(
@@ -71,7 +71,7 @@ class ZipProvider extends TestCase {
 		$this->project = new \Required\Traduttore\Project( GP::$project->get( $this->translation_set->project_id ) );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		/* @var WP_Filesystem_Base $wp_filesystem */
 		global $wp_filesystem;
 
@@ -79,7 +79,7 @@ class ZipProvider extends TestCase {
 			require_once ABSPATH . '/wp-admin/includes/admin.php';
 
 			if ( ! \WP_Filesystem() ) {
-				return false;
+				return;
 			}
 		}
 
@@ -214,7 +214,7 @@ class ZipProvider extends TestCase {
 
 		$file_after = $zip_after->statName( 'foo.txt' );
 
-		$this->assertInternalType( 'array', $file_before );
+		$this->assertIsArray( $file_before );
 		$this->assertFalse( $file_after );
 	}
 
@@ -324,7 +324,11 @@ class ZipProvider extends TestCase {
 		$provider = new Provider( $this->translation_set );
 		$result   = $provider->generate_zip_file();
 
-		$expected_files = [ 'foo-bar-baz-de_DE.po', 'foo-bar-baz-de_DE.mo' ];
+		$expected_files = [
+		  'foo-bar-baz-de_DE.po',
+		  'foo-bar-baz-de_DE.mo',
+		  'foo-bar-baz-de_DE.l10n.php'
+		];
 		$actual_files   = [];
 
 		$zip = new ZipArchive();
@@ -352,7 +356,7 @@ class ZipProvider extends TestCase {
 		$after = wp_next_scheduled( 'traduttore.generate_zip', [ $this->translation_set->id ] );
 
 		$this->assertFalse( $before );
-		$this->assertInternalType( 'int', $after );
+		$this->assertIsInt( $after );
 	}
 
 	public function test_schedule_generation_removes_existing_event(): void {
@@ -426,7 +430,7 @@ class ZipProvider extends TestCase {
 
 		$this->assertFalse( $before );
 		$this->assertTrue( $result );
-		$this->assertInternalType( 'int', $after );
+		$this->assertIsInt( $after );
 	}
 
 	public function test_does_not_schedule_generation_after_importing_originals_for_inactive_project(): void {
@@ -459,7 +463,7 @@ class ZipProvider extends TestCase {
 		$after                 = wp_next_scheduled( 'traduttore.generate_zip', [ $this->translation_set->id ] );
 
 		$this->assertFalse( $before );
-		$this->assertInternalType( 'int', $after );
+		$this->assertIsInt( $after );
 		$this->assertCount( 0, $originals_for_project );
 	}
 }

--- a/traduttore.php
+++ b/traduttore.php
@@ -11,7 +11,8 @@
  * Text Domain: traduttore
  * Domain Path: /languages
  * Update URI:  false
- * Requires PHP: 7.4
+ * Requires PHP: 8.1
+ * Requires Plugins: glotpress
  *
  * Copyright (c) 2017-2022 required (email: info@required.ch)
  *

--- a/traduttore.php
+++ b/traduttore.php
@@ -11,6 +11,7 @@
  * Text Domain: traduttore
  * Domain Path: /languages
  * Update URI:  false
+ * Requires PHP: 7.4
  *
  * Copyright (c) 2017-2022 required (email: info@required.ch)
  *


### PR DESCRIPTION
**Description**
<!-- Please describe what you have changed or added -->

* Require PHP 7.4
* Requires GlotPress 4.0
* Add support for PHP translation files
* Improve tests & logic for webhook handlers
* Improve code quality, enforcing PHPStan level 9
* Verify SHA 256 signatures for GitHub webhooks instead of SHA1
* Fixes Behat code coverage configuration

Fixes #237
Fixes #256
Fixes #257
Fixes #241
Fixes #123

**How has this been tested?**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Unit tests all pass.

**Screenshots**

N/A


**Types of changes**

Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
