### PR TITLE
Clone a specific Git branch

### DIFF
--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -44,9 +44,13 @@ class Git extends Base {
 		);
 
 		/**
-		 * Allows to clone a specific Git branch.
+		 * Filters which Git branch is checked out when the repository is cloned.
 		 *
-		 * @param string $branch The Git branch to clone.
+		 * Use this to instruct Traduttore to clone a branch other than the default.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param string $branch Name of the Git branch to clone. Empty string clones the default branch.
 		 */
 		$branch = apply_filters( 'traduttore.git_clone_branch', '' );
 		if ( '' !== $branch ) {

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -37,17 +37,23 @@ class Git extends Base {
 			return 0 === $status ? $target : null;
 		}
 
-		exec(
-			escapeshellcmd(
-				sprintf(
-					'git clone --depth=1 %1$s %2$s -q',
-					escapeshellarg( $this->get_clone_url() ),
-					escapeshellarg( $target )
-				)
-			),
-			$output,
-			$status
+		$cmd = sprintf(
+			'git clone --depth 1 %s %s',
+			escapeshellarg( $this->get_clone_url() ),
+			escapeshellarg( $target )
 		);
+
+		/**
+		 * Allows to clone a specific Git branch.
+		 *
+		 * @param string $branch The Git branch to clone.
+		 */
+		$branch = apply_filters( 'traduttore.git_branch_specifier', '' );
+		if ( '' !== $branch ) {
+			$cmd .= ' --branch ' . escapeshellarg( $branch );
+		}
+
+		exec( escapeshellcmd( $cmd ), $output, $status );
 
 		return 0 === $status ? $target : null;
 	}

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -48,7 +48,7 @@ class Git extends Base {
 		 *
 		 * @param string $branch The Git branch to clone.
 		 */
-		$branch = apply_filters( 'traduttore.git_branch_specifier', '' );
+		$branch = apply_filters( 'traduttore.git_clone_branch', '' );
 		if ( '' !== $branch ) {
 			$cmd .= ' --branch ' . escapeshellarg( $branch );
 		}


### PR DESCRIPTION
### Description

This PR adds support for specifying a custom Git branch when triggering a translation build in Traduttore.

### Motivation

Currently, Traduttore assumes that translations are always built from the repository’s default branch. This can be limiting in scenarios where a different branch needs to be translated—for example, feature branches or specific release branches.