### PR TITLE
Fix check for default branch on received webhook, allowing for a custom one

### DIFF
--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -52,7 +52,7 @@ class Git extends Base {
 		 *
 		 * @param string $branch Name of the Git branch to clone. Empty string clones the default branch.
 		 */
-		$branch = apply_filters( 'traduttore.git_clone_branch', '' );
+		$branch = apply_filters( 'traduttore.git_clone_branch', '', $this->repository->get_name() );
 		if ( '' !== $branch ) {
 			$cmd .= ' --branch ' . escapeshellarg( $branch );
 		}

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -51,6 +51,7 @@ class Git extends Base {
 		 * @since 4.0.0
 		 *
 		 * @param string $branch Name of the Git branch to clone. Empty string clones the default branch.
+		 * @param string|null $repository Name of the repository. Can be used to resolve the project.
 		 */
 		$branch = apply_filters( 'traduttore.git_clone_branch', '', $this->repository->get_name() );
 		if ( '' !== $branch ) {

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -79,10 +79,10 @@ class Git extends Base {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool                                   $use_https  Whether to use HTTPS instead of SSH for
-		 *                                                           cloning repositories.
-		 *                                                           Defaults to true for public repositories.
-		 * @param \Required\Traduttore\Loader\Repository $repository The current repository.
+		 * @param bool                            $use_https  Whether to use HTTPS instead of SSH for
+		 *                                                    cloning repositories.
+		 *                                                    Defaults to true for public repositories.
+		 * @param \Required\Traduttore\Repository $repository The current repository.
 		 */
 		$use_https = apply_filters( 'traduttore.git_clone_use_https', $this->repository->is_public(), $this->repository );
 
@@ -97,8 +97,8 @@ class Git extends Base {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string                                 $clone_url  The URL to clone a Git repository.
-		 * @param \Required\Traduttore\Loader\Repository $repository The current repository.
+		 * @param string                          $clone_url  The URL to clone a Git repository.
+		 * @param \Required\Traduttore\Repository $repository The current repository.
 		 */
 		return apply_filters( 'traduttore.git_clone_url', (string) $clone_url, $this->repository );
 	}

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -79,10 +79,10 @@ class Git extends Base {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool                            $use_https  Whether to use HTTPS instead of SSH for
-		 *                                                    cloning repositories.
-		 *                                                    Defaults to true for public repositories.
-		 * @param Repository $repository The current repository.
+		 * @param bool                                   $use_https  Whether to use HTTPS instead of SSH for
+		 *                                                           cloning repositories.
+		 *                                                           Defaults to true for public repositories.
+		 * @param \Required\Traduttore\Loader\Repository $repository The current repository.
 		 */
 		$use_https = apply_filters( 'traduttore.git_clone_use_https', $this->repository->is_public(), $this->repository );
 
@@ -97,8 +97,8 @@ class Git extends Base {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string                          $clone_url  The URL to clone a Git repository.
-		 * @param Repository $repository The current repository.
+		 * @param string                                 $clone_url  The URL to clone a Git repository.
+		 * @param \Required\Traduttore\Loader\Repository $repository The current repository.
 		 */
 		return apply_filters( 'traduttore.git_clone_url', (string) $clone_url, $this->repository );
 	}

--- a/inc/Loader/Git.php
+++ b/inc/Loader/Git.php
@@ -51,9 +51,9 @@ class Git extends Base {
 		 * @since 4.0.0
 		 *
 		 * @param string $branch Name of the Git branch to clone. Empty string clones the default branch.
-		 * @param string|null $repository Name of the repository. Can be used to resolve the project.
+		 * @param \Required\Traduttore\Repository $repository Full repository instance.
 		 */
-		$branch = apply_filters( 'traduttore.git_clone_branch', '', $this->repository->get_name() );
+		$branch = apply_filters( 'traduttore.git_clone_branch', '', $this->repository );
 		if ( '' !== $branch ) {
 			$cmd .= ' --branch ' . escapeshellarg( $branch );
 		}
@@ -82,7 +82,7 @@ class Git extends Base {
 		 * @param bool                            $use_https  Whether to use HTTPS instead of SSH for
 		 *                                                    cloning repositories.
 		 *                                                    Defaults to true for public repositories.
-		 * @param \Required\Traduttore\Repository $repository The current repository.
+		 * @param Repository $repository The current repository.
 		 */
 		$use_https = apply_filters( 'traduttore.git_clone_use_https', $this->repository->is_public(), $this->repository );
 
@@ -98,7 +98,7 @@ class Git extends Base {
 		 * @since 3.0.0
 		 *
 		 * @param string                          $clone_url  The URL to clone a Git repository.
-		 * @param \Required\Traduttore\Repository $repository The current repository.
+		 * @param Repository $repository The current repository.
 		 */
 		return apply_filters( 'traduttore.git_clone_url', (string) $clone_url, $this->repository );
 	}

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -108,7 +108,7 @@ abstract class Base implements WebhookHandler {
 			return $project;
 		}
 
-		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch, $project );
+		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch, $project->get_name() );
 
 		// We only care about the default or custom branch but don't want to send an error still.
 		if ( $branch !== $ref ) {

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -96,7 +96,7 @@ abstract class Base implements WebhookHandler {
 	 * @param string $ref Name of the received branch through the webhook.
 	 * @return \Required\Traduttore\Project|\WP_REST_Response|\WP_Error
 	 */
-	protected function get_validated_project( string $repository, string $default_branch = '', string $ref = '' ): Project|WP_REST_Response|\WP_Error {
+	protected function resolve_project( string $repository, string $default_branch = '', string $ref = '' ): Project|WP_REST_Response|\WP_Error {
 		$locator = new ProjectLocator( $repository );
 		$project = $locator->get_project();
 

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -108,7 +108,7 @@ abstract class Base implements WebhookHandler {
 			return $project;
 		}
 
-		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch, $project->get_name() );
+		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch, $project->get_repository_name() );
 
 		// We only care about the default or custom branch but don't want to send an error still.
 		if ( $branch !== $ref ) {

--- a/inc/WebhookHandler/Base.php
+++ b/inc/WebhookHandler/Base.php
@@ -108,7 +108,7 @@ abstract class Base implements WebhookHandler {
 			return $project;
 		}
 
-		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch );
+		$branch = 'refs/heads/' . (string) apply_filters( 'traduttore.git_clone_branch', $default_branch, $project );
 
 		// We only care about the default or custom branch but don't want to send an error still.
 		if ( $branch !== $ref ) {

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -80,12 +80,13 @@ class Bitbucket extends Base {
 		 * @var array{repository: array{scm: string, full_name: string, links: array{html: array{href: string}}, is_private: bool}} $params
 		 */
 		$params = $this->request->get_params();
+		$href   = (string) $params['repository']['links']['html']['href'];
 
-		if ( ! isset( $params['repository']['links']['html']['href'] ) ) {
+		if ( '' === $href ) {
 			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
 		}
 
-		$project = $this->get_validated_project( $params['repository']['links']['html']['href'] );
+		$project = $this->resolve_project( $href );
 
 		if ( ! $project instanceof Project ) {
 			return $project;
@@ -96,7 +97,7 @@ class Bitbucket extends Base {
 		}
 
 		$project->set_repository_name( $params['repository']['full_name'] );
-		$project->set_repository_url( $params['repository']['links']['html']['href'] );
+		$project->set_repository_url( $href );
 
 		$ssh_url   = sprintf( 'git@bitbucket.org:%s.git', $project->get_repository_name() );
 		$https_url = sprintf( 'https://bitbucket.org/%s.git', $project->get_repository_name() );

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -7,6 +7,7 @@
 
 namespace Required\Traduttore\WebhookHandler;
 
+use Required\Traduttore\Project;
 use Required\Traduttore\ProjectLocator;
 use Required\Traduttore\Repository;
 use Required\Traduttore\Updater;
@@ -80,11 +81,14 @@ class Bitbucket extends Base {
 		 */
 		$params = $this->request->get_params();
 
-		$locator = new ProjectLocator( $params['repository']['links']['html']['href'] );
-		$project = $locator->get_project();
+		if ( ! isset( $params['repository']['links']['html']['href'] ) ) {
+			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
+		}
 
-		if ( ! $project ) {
-			return new \WP_Error( '404', 'Could not find project for this repository' );
+		$project = $this->get_validated_project( $params['repository']['links']['html']['href'] );
+
+		if ( ! $project instanceof Project ) {
+			return $project;
 		}
 
 		if ( ! $project->get_repository_vcs_type() ) {

--- a/inc/WebhookHandler/Bitbucket.php
+++ b/inc/WebhookHandler/Bitbucket.php
@@ -82,10 +82,6 @@ class Bitbucket extends Base {
 		$params = $this->request->get_params();
 		$href   = (string) $params['repository']['links']['html']['href'];
 
-		if ( '' === $href ) {
-			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
-		}
-
 		$project = $this->resolve_project( $href );
 
 		if ( ! $project instanceof Project ) {

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -118,21 +118,25 @@ class GitHub extends Base {
 		 * @var array{repository: array{ default_branch?: string, html_url: string, full_name: string, ssh_url: string, clone_url: string, private: bool }, ref: string } $params
 		 */
 
-		if ( ! isset( $params['repository']['default_branch'] )
-			| ! isset( $params['repository']['html_url'] )
-			| ! isset( $params['ref'] )
+		$default_branch = (string) $params['repository']['default_branch'] ?? '';
+		$html_url       = (string) $params['repository']['html_url'];
+		$ref            = (string) $params['ref'];
+
+		if ( '' === $default_branch
+			| '' === $html_url
+			| '' === $ref
 		) {
 			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
 		}
 
-		$project = $this->get_validated_project( $params['repository']['html_url'], $params['repository']['default_branch'], $params['ref'] );
+		$project = $this->resolve_project( $html_url, $default_branch, $ref );
 
 		if ( ! $project instanceof Project ) {
 			return $project;
 		}
 
 		$project->set_repository_name( $params['repository']['full_name'] );
-		$project->set_repository_url( $params['repository']['html_url'] );
+		$project->set_repository_url( $html_url );
 		$project->set_repository_ssh_url( $params['repository']['ssh_url'] );
 		$project->set_repository_https_url( $params['repository']['clone_url'] );
 		$project->set_repository_visibility( false === $params['repository']['private'] ? 'public' : 'private' );

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -118,7 +118,7 @@ class GitHub extends Base {
 		 * @var array{repository: array{ default_branch?: string, html_url: string, full_name: string, ssh_url: string, clone_url: string, private: bool }, ref: string } $params
 		 */
 
-		$default_branch = (string) $params['repository']['default_branch'] ?? '';
+		$default_branch = (string) $params['repository']['default_branch'] ?: '';
 		$html_url       = (string) $params['repository']['html_url'];
 		$ref            = (string) $params['ref'];
 

--- a/inc/WebhookHandler/GitHub.php
+++ b/inc/WebhookHandler/GitHub.php
@@ -118,7 +118,7 @@ class GitHub extends Base {
 		 * @var array{repository: array{ default_branch?: string, html_url: string, full_name: string, ssh_url: string, clone_url: string, private: bool }, ref: string } $params
 		 */
 
-		$default_branch = (string) $params['repository']['default_branch'] ?: '';
+		$default_branch = (string) ( $params['repository']['default_branch'] ?? '' );
 		$html_url       = (string) $params['repository']['html_url'];
 		$ref            = (string) $params['ref'];
 

--- a/inc/WebhookHandler/GitLab.php
+++ b/inc/WebhookHandler/GitLab.php
@@ -78,23 +78,26 @@ class GitLab extends Base {
 		 *
 		 * @var array{project: array{default_branch: string, homepage: string, path_with_namespace: string, ssh_url: string, http_url: string, visibility_level: int}, ref: string} $params
 		 */
-		$params = $this->request->get_params();
+		$params         = $this->request->get_params();
+		$default_branch = (string) $params['project']['default_branch'];
+		$homepage       = (string) $params['project']['homepage'];
+		$ref            = (string) $params['ref'];
 
-		if ( ! isset( $params['project']['default_branch'] )
-			| ! isset( $params['project']['homepage'] )
-			| ! isset( $params['ref'] )
+		if ( '' === $default_branch
+			| '' === $homepage
+			| '' === $ref
 		) {
 			return new \WP_Error( '400', 'Request incomplete', [ 'status' => 400 ] );
 		}
 
-		$project = $this->get_validated_project( $params['project']['homepage'], $params['project']['default_branch'], $params['ref'] );
+		$project = $this->resolve_project( $homepage, $default_branch, $ref );
 
 		if ( ! $project instanceof Project ) {
 			return $project;
 		}
 
 		$project->set_repository_name( $params['project']['path_with_namespace'] );
-		$project->set_repository_url( $params['project']['homepage'] );
+		$project->set_repository_url( $homepage );
 		$project->set_repository_ssh_url( $params['project']['ssh_url'] );
 		$project->set_repository_https_url( $params['project']['http_url'] );
 		$project->set_repository_visibility( 20 === $params['project']['visibility_level'] ? 'public' : 'private' );

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -110,6 +110,34 @@ class Bitbucket extends TestCase {
 		$this->assertErrorResponse( 404, $response );
 	}
 
+	public function test_request_incomplete(): void {
+		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				[
+					'ref'        => 'refs/heads/master',
+					'repository' => [
+						'links'      => [
+							'html' => [
+								'href' => '',
+							],
+						],
+						'full_name'  => 'wearerequired/traduttore',
+						'scm'        => 'git',
+						'is_private' => false,
+					],
+				]
+			)
+		);
+		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
+		$request->add_header( 'x-event-key', 'repo:push' );
+		$request->add_header( 'x-hub-signature-256', $signature );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 400, $response );
+	}
+
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->add_header( 'Content-Type', 'application/json' );

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -110,34 +110,6 @@ class Bitbucket extends TestCase {
 		$this->assertErrorResponse( 404, $response );
 	}
 
-	public function test_request_incomplete(): void {
-		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
-		$request->add_header( 'Content-Type', 'application/json' );
-		$request->set_body(
-			(string) wp_json_encode(
-				[
-					'ref'        => 'refs/heads/master',
-					'repository' => [
-						'links'      => [
-							'html' => [
-								'href' => '',
-							],
-						],
-						'full_name'  => 'wearerequired/traduttore',
-						'scm'        => 'git',
-						'is_private' => false,
-					],
-				]
-			)
-		);
-		$signature = 'sha256=' . hash_hmac( 'sha256', $request->get_body(), 'traduttore-test' );
-		$request->add_header( 'x-event-key', 'repo:push' );
-		$request->add_header( 'x-hub-signature-256', $signature );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertErrorResponse( 'rest_forbidden', $response, 400 );
-	}
-
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->add_header( 'Content-Type', 'application/json' );

--- a/tests/phpunit/tests/WebhookHandler/Bitbucket.php
+++ b/tests/phpunit/tests/WebhookHandler/Bitbucket.php
@@ -135,7 +135,7 @@ class Bitbucket extends TestCase {
 		$request->add_header( 'x-hub-signature-256', $signature );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 400, $response );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 400 );
 	}
 
 	public function test_valid_project(): void {

--- a/tests/phpunit/tests/WebhookHandler/GitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/GitHub.php
@@ -96,7 +96,7 @@ class GitHub extends TestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
+		$this->assertSame( [ 'result' => 'Not the default or custom branch' ], $response->get_data() );
 	}
 
 	public function test_invalid_project(): void {

--- a/tests/phpunit/tests/WebhookHandler/GitLab.php
+++ b/tests/phpunit/tests/WebhookHandler/GitLab.php
@@ -106,6 +106,28 @@ class GitLab extends TestCase {
 		$this->assertErrorResponse( 404, $response );
 	}
 
+	public function test_request_incomplete(): void {
+		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
+		$request->set_body_params(
+			[
+				'ref'     => '',
+				'project' => [
+					'default_branch'      => 'master',
+					'path_with_namespace' => 'wearerequired/traduttore',
+					'homepage'            => 'https://gitlab.com/wearerequired/traduttore',
+					'http_url'            => 'https://gitlab.com/wearerequired/traduttore.git',
+					'ssh_url'             => 'git@gitlab.com/wearerequired/traduttore.git',
+					'visibility_level'    => 20,
+				],
+			]
+		);
+		$request->add_header( 'x-gitlab-event', 'Push Hook' );
+		$request->add_header( 'x-gitlab-token', 'traduttore-test' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 400, $response );
+	}
+
 	public function test_valid_project(): void {
 		$request = new WP_REST_Request( 'POST', '/traduttore/v1/incoming-webhook' );
 		$request->set_body_params(

--- a/tests/phpunit/tests/WebhookHandler/GitLab.php
+++ b/tests/phpunit/tests/WebhookHandler/GitLab.php
@@ -81,7 +81,7 @@ class GitLab extends TestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
+		$this->assertSame( [ 'result' => 'Not the default or custom branch' ], $response->get_data() );
 	}
 
 	public function test_invalid_project(): void {

--- a/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
+++ b/tests/phpunit/tests/WebhookHandler/LegacyGitHub.php
@@ -93,7 +93,7 @@ class LegacyGitHub extends TestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [ 'result' => 'Not the default branch' ], $response->get_data() );
+		$this->assertSame( [ 'result' => 'Not the default or custom branch' ], $response->get_data() );
 	}
 
 	public function test_invalid_project(): void {


### PR DESCRIPTION
**Description**

Add the filter to customize the branch to elaborate when a webhook is received. Since most of the logic is common between the handlers, it has been extracted to the Base class.

Add the repository name to the existing filter to allow resolving the project inside the filter.

**How has this been tested?**

I tested this feature locally with some limitations. I tested sending a webhook, and I can see the request is going through without errors.

**Types of changes**

Bug fix (non-breaking change which fixes an issue)
Fixes #280 

**Checklist:**
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `composer run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
